### PR TITLE
On Linux, eat+warn EPERM errors on send_to due to conntrack

### DIFF
--- a/src/dht.rs
+++ b/src/dht.rs
@@ -758,7 +758,7 @@ impl DHT {
             Ok(_) => Ok(()),
             Err(e) => {
                 #[cfg(target_os = "linux")]
-                if e.kind() == std::io::ErrorKind::PermissionDenied && std::env::o {
+                if e.kind() == std::io::ErrorKind::PermissionDenied {
                     warn!(target: "rustydht_lib::DHT", "send_to resulted in PermissionDenied. Is conntrack table full?");
                     return Ok(());
                 }

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -754,11 +754,17 @@ impl DHT {
     }
 
     async fn send_to(&self, bytes: &Vec<u8>, dest: SocketAddr) -> Result<(), RustyDHTError> {
-        self.socket
-            .send_to(bytes, dest)
-            .await
-            .map_err(|err| RustyDHTError::GeneralError(err.into()))?;
-        Ok(())
+        match self.socket.send_to(bytes, dest).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                #[cfg(target_os = "linux")]
+                if e.kind() == std::io::ErrorKind::PermissionDenied && std::env::o {
+                    warn!(target: "rustydht_lib::DHT", "send_to resulted in PermissionDenied. Is conntrack table full?");
+                    return Ok(());
+                }
+                Err(RustyDHTError::GeneralError(e.into()))
+            }
+        }
     }
 
     /// Adds a 'vote' for whatever IP address the sender says we have.


### PR DESCRIPTION
Linux kernel fails send_to calls with EPERM when the conntrack table is full. See https://blog.cloudflare.com/conntrack-tales-one-thousand-and-one-flows/

Best fix for us is probably to disable conntrack with iptables since we don't need stateful connection tracking. But this fix just makes send_to eat the error and log a warning about it.