### PR TITLE
Add convenient DHT operations methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased] - 2022-01-02
 * Remove `timestamps` features from `simple_logger` in dev-dependencies. The time crate is intermittently failing to get local timezone offset and causing a crash while logging.
+* Add `dht::operations` module with functions to announce_peer, find_node, and get_peers.
 
 ## [v2.0.1] - 2022-01-01
 * Fix a Windows-only bug that can cause DHTSocket to error if someone sends it a datagram larger than the receive buffer.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,7 @@ thiserror = "1.0.25"
 tokio = { version = "1", features = ["rt","net", "time", "macros", "sync"] }
 
 [dev-dependencies]
+clap = "^2"
+simple_logger = "^1"
 rand_chacha = "0.3.0"
+tokio = { version = "1", features = ["rt","net", "time", "macros", "sync", "signal"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,3 +7,11 @@ This example runs a DHT node and provides a small HTTP status page on localhost.
 ```
 cargo run --example dht_node -- -l 6881 -h 8080
 ```
+
+## find_nodes
+Command line tool that takes a target Id on the command line and searches the DHT for the nodes with the nearest Ids.
+
+**Example:**
+```
+cargo run --example find_nodes -- -i ffffffffffffffffffffffffffffffffffffffff
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,13 @@
 # Examples
 
+## announce_peer
+Command line tool that takes a target info_hash and port, then announces to the DHT that your IP address is a peer for that torrent on the provided port.
+
+**Example:**
+```
+cargo run --example announce_peer -- -i 1A70F7C9C882B5298F555AA7F4915E68A4F31C7E
+```
+
 ## dht_node
 This example runs a DHT node and provides a small HTTP status page on localhost. The DHT and HTTP ports can be configured by command line arguments.
 
@@ -14,4 +22,12 @@ Command line tool that takes a target Id on the command line and searches the DH
 **Example:**
 ```
 cargo run --example find_nodes -- -i ffffffffffffffffffffffffffffffffffffffff
+```
+
+## get_peers
+Command line tool that takes a torrent info_hash and searches the DHT for peers.
+
+**Example:**
+```
+cargo run --example get_peers -- -i 6193AFC361B2896F2337E336BA9949B8EA8ACF5C
 ```

--- a/examples/announce_peer.rs
+++ b/examples/announce_peer.rs
@@ -115,7 +115,7 @@ async fn main() {
             shutdown_tx.shutdown().await;
         },
         _ = async move {
-            let nodes = operations::announce_peer(&dht_clone, info_hash, announce_port, timeout).await;
+            let nodes = operations::announce_peer(&dht_clone, info_hash, announce_port, timeout).await.expect("announce_peer hit an error");
             println!("Announced to:\n{:?}", nodes);
         } => {}
     }

--- a/examples/announce_peer.rs
+++ b/examples/announce_peer.rs
@@ -1,0 +1,122 @@
+use clap::{App, Arg};
+use log::LevelFilter;
+use rustydht_lib::common::ipv4_addr_src::IPV4Consensus;
+use rustydht_lib::common::Id;
+use rustydht_lib::dht;
+use rustydht_lib::dht::operations;
+use rustydht_lib::shutdown;
+use rustydht_lib::storage::node_bucket_storage::{NodeBucketStorage, NodeStorage};
+use simple_logger::SimpleLogger;
+use std::sync::Arc;
+use std::time::Duration;
+
+const ROUTERS: [&str; 3] = [
+    "router.bittorrent.com:6881",
+    "router.utorrent.com:6881",
+    "dht.transmissionbt.com:6881",
+];
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    SimpleLogger::new()
+        .with_level(LevelFilter::Warn)
+        .with_module_level("rustydht_lib::operations", LevelFilter::Trace)
+        .init()
+        .expect("Failed to initialize logging");
+
+    let cmdline_matches = App::new("announce_Peer")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about("Example application for rustydht-lib. Announces your IP as a peer for the provided info_hash")
+        .arg(
+            Arg::with_name("dht_listen_port")
+                .short("l")
+                .default_value("6881")
+                .help("The UDP port that the DHT will bind to")
+        )
+        .arg(
+            Arg::with_name("info_hash")
+                .short("i")
+                .required(true)
+                .takes_value(true)
+                .help("The info hash for which we should find peers")
+        )
+        .arg(
+            Arg::with_name("announce_port")
+                .short("p")
+                .required(false)
+                .takes_value(true)
+                .help("The port that you want to announce for peers to connect to you on")
+        )
+        .arg(
+            Arg::with_name("timeout")
+                .short("t")
+                .default_value("60")
+                .help("Stop searching for nodes to announce to after this many seconds have elapsed")
+        )
+        .get_matches();
+
+    let port: u16 = cmdline_matches
+        .value_of("dht_listen_port")
+        .expect("No value specified for listen port")
+        .parse()
+        .expect("Invalid value for listen port");
+
+    let info_hash = Id::from_hex(
+        &cmdline_matches
+            .value_of("info_hash")
+            .expect("No value specified for info_hash"),
+    )
+    .expect("Failed to parse info_hash");
+
+    let announce_port: Option<u16> = match cmdline_matches.value_of("announce_port") {
+        Some(ap_str) => {
+            let ap: u16 = ap_str.parse().expect("Invalid value for announce_port");
+            Some(ap)
+        }
+        None => None,
+    };
+
+    let timeout = Duration::from_secs(
+        cmdline_matches
+            .value_of("timeout")
+            .expect("No value for timeout")
+            .parse()
+            .expect("Invalid timeout"),
+    );
+
+    let (mut shutdown_tx, shutdown_rx) = shutdown::create_shutdown();
+    let ip_source = Box::new(IPV4Consensus::new(2, 10));
+    let buckets = |id| -> Box<dyn NodeStorage + Send> { Box::new(NodeBucketStorage::new(id, 8)) };
+    let mut settings = dht::DHTSettings::default();
+    settings.read_only = true;
+    let dht = Arc::new(
+        dht::DHT::new(
+            shutdown_rx.clone(),
+            None,
+            port,
+            ip_source,
+            buckets,
+            &ROUTERS,
+            settings,
+        )
+        .await
+        .expect("Failed to init DHT"),
+    );
+
+    let dht_clone = dht.clone();
+
+    tokio::select! {
+        _ = dht.run_event_loop() => {},
+        _ = tokio::signal::ctrl_c() => {
+            eprintln!("Ctrl+c detected - sending shutdown signal");
+            drop(dht);
+            drop(shutdown_rx);
+            shutdown_tx.shutdown().await;
+        },
+        _ = async move {
+            let nodes = operations::announce_peer(&dht_clone, info_hash, announce_port, timeout).await;
+            println!("Announced to:\n{:?}", nodes);
+        } => {}
+    }
+}

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -100,7 +100,7 @@ async fn main() {
             shutdown_tx.shutdown().await;
         },
         _ = async move {
-            let nodes = operations::find_node(&dht_clone, info_hash, timeout).await;
+            let nodes = operations::find_node(&dht_clone, info_hash, timeout).await.expect("find_node hit an error");
             println!("Nodes:\n{:?}", nodes);
         } => {}
     }

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -1,0 +1,107 @@
+use clap::{App, Arg};
+use log::LevelFilter;
+use rustydht_lib::common::ipv4_addr_src::IPV4Consensus;
+use rustydht_lib::common::Id;
+use rustydht_lib::dht;
+use rustydht_lib::dht::operations;
+use rustydht_lib::shutdown;
+use rustydht_lib::storage::node_bucket_storage::{NodeBucketStorage, NodeStorage};
+use simple_logger::SimpleLogger;
+use std::sync::Arc;
+use std::time::Duration;
+
+const ROUTERS: [&str; 3] = [
+    "router.bittorrent.com:6881",
+    "router.utorrent.com:6881",
+    "dht.transmissionbt.com:6881",
+];
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    SimpleLogger::new()
+        .with_level(LevelFilter::Warn)
+        .with_module_level("rustydht_lib::operations", LevelFilter::Trace)
+        .init()
+        .expect("Failed to initialize logging");
+
+    let cmdline_matches = App::new("find_nodes")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about("Example application for rustydht-lib. Finds the 8 nearest nodes to an info hash")
+        .arg(
+            Arg::with_name("dht_listen_port")
+                .short("l")
+                .default_value("6881")
+                .help("The UDP port that the DHT will bind to"),
+        )
+        .arg(
+            Arg::with_name("info_hash")
+                .short("i")
+                .required(true)
+                .takes_value(true)
+                .help("The info hash for which we should find peers"),
+        )
+        .arg(
+            Arg::with_name("timeout")
+                .short("t")
+                .default_value("60")
+                .help("Stop searching after this many seconds have elapsed"),
+        )
+        .get_matches();
+
+    let port: u16 = cmdline_matches
+        .value_of("dht_listen_port")
+        .expect("No value specified for listen port")
+        .parse()
+        .expect("Invalid value for listen port");
+
+    let info_hash = Id::from_hex(
+        &cmdline_matches
+            .value_of("info_hash")
+            .expect("No value specified for info_hash"),
+    )
+    .expect("Failed to parse info_hash");
+
+    let timeout = Duration::from_secs(
+        cmdline_matches
+            .value_of("timeout")
+            .expect("No value for timeout")
+            .parse()
+            .expect("Invalid timeout"),
+    );
+
+    let (mut shutdown_tx, shutdown_rx) = shutdown::create_shutdown();
+    let ip_source = Box::new(IPV4Consensus::new(2, 10));
+    let buckets = |id| -> Box<dyn NodeStorage + Send> { Box::new(NodeBucketStorage::new(id, 8)) };
+    let mut settings = dht::DHTSettings::default();
+    settings.read_only = true;
+    let dht = Arc::new(
+        dht::DHT::new(
+            shutdown_rx.clone(),
+            None,
+            port,
+            ip_source,
+            buckets,
+            &ROUTERS,
+            settings,
+        )
+        .await
+        .expect("Failed to init DHT"),
+    );
+
+    let dht_clone = dht.clone();
+
+    tokio::select! {
+        _ = dht.run_event_loop() => {},
+        _ = tokio::signal::ctrl_c() => {
+            eprintln!("Ctrl+c detected - sending shutdown signal");
+            drop(dht);
+            drop(shutdown_rx);
+            shutdown_tx.shutdown().await;
+        },
+        _ = async move {
+            let nodes = operations::find_node(&dht_clone, info_hash, timeout).await;
+            println!("Nodes:\n{:?}", nodes);
+        } => {}
+    }
+}

--- a/examples/get_peers.rs
+++ b/examples/get_peers.rs
@@ -77,13 +77,12 @@ async fn main() {
     tokio::select! {
         _ = dht.run_event_loop() => {},
         _ = tokio::signal::ctrl_c() => {
-            println!("Ctrl+c detected - sending shutdown signal");
+            eprintln!("Ctrl+c detected - sending shutdown signal");
             drop(dht);
             drop(shutdown_rx);
             shutdown_tx.shutdown().await;
         },
         _ = async move {
-            println!("Starting get_peers");
             let peers = operations::get_peers(&dht_clone, info_hash, 1).await;
             println!("Peers:\n{:?}", peers);
         } => {}

--- a/examples/get_peers.rs
+++ b/examples/get_peers.rs
@@ -100,8 +100,8 @@ async fn main() {
             shutdown_tx.shutdown().await;
         },
         _ = async move {
-            let result = operations::get_peers(&dht_clone, info_hash, timeout).await;
-            println!("Peers:\n{:?}", result.peers);
+            let result = operations::get_peers(&dht_clone, info_hash, timeout).await.expect("get_peers hit an error");
+            println!("Peers:\n{:?}", result.peers());
         } => {}
     }
 }

--- a/examples/get_peers.rs
+++ b/examples/get_peers.rs
@@ -47,12 +47,6 @@ async fn main() {
                 .default_value("60")
                 .help("Stop searching after this many seconds have elapsed"),
         )
-        .arg(
-            Arg::with_name("desired_peers")
-                .short("d")
-                .default_value("1")
-                .help("Stop searching after this number of peers have been found"),
-        )
         .get_matches();
 
     let port: u16 = cmdline_matches
@@ -75,12 +69,6 @@ async fn main() {
             .parse()
             .expect("Invalid timeout"),
     );
-
-    let desired_peers = cmdline_matches
-        .value_of("desired_peers")
-        .expect("No value for desired_peers")
-        .parse()
-        .expect("Invalid desired_peers");
 
     let (mut shutdown_tx, shutdown_rx) = shutdown::create_shutdown();
     let ip_source = Box::new(IPV4Consensus::new(2, 10));
@@ -112,8 +100,8 @@ async fn main() {
             shutdown_tx.shutdown().await;
         },
         _ = async move {
-            let peers = operations::get_peers(&dht_clone, info_hash, desired_peers, timeout).await;
-            println!("Peers:\n{:?}", peers);
+            let result = operations::get_peers(&dht_clone, info_hash, timeout).await;
+            println!("Peers:\n{:?}", result.peers);
         } => {}
     }
 }

--- a/examples/get_peers.rs
+++ b/examples/get_peers.rs
@@ -1,0 +1,91 @@
+use clap::{App, Arg};
+use log::LevelFilter;
+use rustydht_lib::common::ipv4_addr_src::IPV4Consensus;
+use rustydht_lib::common::Id;
+use rustydht_lib::dht;
+use rustydht_lib::dht::operations;
+use rustydht_lib::shutdown;
+use rustydht_lib::storage::node_bucket_storage::{NodeBucketStorage, NodeStorage};
+use simple_logger::SimpleLogger;
+use std::sync::Arc;
+
+const ROUTERS: [&str; 3] = [
+    "router.bittorrent.com:6881",
+    "router.utorrent.com:6881",
+    "dht.transmissionbt.com:6881",
+];
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    SimpleLogger::new()
+        .with_level(LevelFilter::Warn)
+        .with_module_level("rustydht_lib::operations", LevelFilter::Trace)
+        .init()
+        .expect("Failed to initialize logging");
+
+    let cmdline_matches = App::new("get_peers")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about("Example application for rustydht-lib. Retrieves peers for an info_hash.")
+        .arg(
+            Arg::with_name("dht_listen_port")
+                .short("l")
+                .default_value("6881"),
+        )
+        .arg(
+            Arg::with_name("info_hash")
+                .short("i")
+                .required(true)
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let port: u16 = cmdline_matches
+        .value_of("dht_listen_port")
+        .expect("No value specified for listen port")
+        .parse()
+        .expect("Invalid value for listen port");
+
+    let info_hash = Id::from_hex(
+        &cmdline_matches
+            .value_of("info_hash")
+            .expect("No value specified for info_hash"),
+    )
+    .expect("Failed to parse info_hash");
+
+    let (mut shutdown_tx, shutdown_rx) = shutdown::create_shutdown();
+    let ip_source = Box::new(IPV4Consensus::new(2, 10));
+    let buckets = |id| -> Box<dyn NodeStorage + Send> { Box::new(NodeBucketStorage::new(id, 8)) };
+    let mut settings = dht::DHTSettings::default();
+    settings.read_only = true;
+    let dht = Arc::new(
+        dht::DHT::new(
+            shutdown_rx.clone(),
+            None,
+            port,
+            ip_source,
+            buckets,
+            &ROUTERS,
+            settings,
+        )
+        .await
+        .expect("Failed to init DHT"),
+    );
+
+    let dht_clone = dht.clone();
+
+    tokio::select! {
+        _ = dht.run_event_loop() => {},
+        _ = tokio::signal::ctrl_c() => {
+            println!("Ctrl+c detected - sending shutdown signal");
+            drop(dht);
+            drop(shutdown_rx);
+            shutdown_tx.shutdown().await;
+        },
+        _ = async move {
+            println!("Starting get_peers");
+            let peers = operations::get_peers(&dht_clone, info_hash, 1).await;
+            println!("Peers:\n{:?}", peers);
+        } => {}
+    }
+}

--- a/src/dht/dht.rs
+++ b/src/dht/dht.rs
@@ -79,6 +79,11 @@ impl DHT {
         self.state.try_lock().unwrap().buckets.get_all_verified()
     }
 
+    /// Return a copy of the settings used by the DHT
+    pub fn get_settings(&self) -> DHTSettings {
+        self.state.try_lock().unwrap().settings.clone()
+    }
+
     /// Creates a new DHT.
     ///
     /// # Arguments

--- a/src/dht/dht_settings.rs
+++ b/src/dht/dht_settings.rs
@@ -56,6 +56,12 @@ pub struct DHTSettings {
 
     /// We'll think about pruning outgoing requests at this interval
     pub outgoing_reqiest_check_interval_secs: u64,
+
+    /// If true, we will set the read only flag in outgoing requests to prevent 
+    /// other nodes from adding us to their routing tables. This is useful if
+    /// we're behind a restrictive NAT/firewall and can't accept incoming 
+    /// packets from IPs that we haven't sent anything to.
+    pub read_only: bool,
 }
 
 impl DHTSettings {
@@ -78,6 +84,7 @@ impl DHTSettings {
             ping_check_interval_secs: 10,
             outgoing_request_prune_secs: 30,
             outgoing_reqiest_check_interval_secs: 30,
+            read_only: false,
         }
     }
 }

--- a/src/dht/dht_settings.rs
+++ b/src/dht/dht_settings.rs
@@ -6,6 +6,7 @@
 /// Use [DHTSettings::default()](crate::dht::DHTSettings::default) to create an instance with the
 /// 'recommended' defaults (which can be customized). Or instantiate your own
 /// with `let settings = DHTSettings {/* your settings here */};`
+#[derive(Clone)]
 pub struct DHTSettings {
     /// Number of bytes for token secrets for get_peers responses
     pub token_secret_size: usize,
@@ -57,9 +58,9 @@ pub struct DHTSettings {
     /// We'll think about pruning outgoing requests at this interval
     pub outgoing_reqiest_check_interval_secs: u64,
 
-    /// If true, we will set the read only flag in outgoing requests to prevent 
+    /// If true, we will set the read only flag in outgoing requests to prevent
     /// other nodes from adding us to their routing tables. This is useful if
-    /// we're behind a restrictive NAT/firewall and can't accept incoming 
+    /// we're behind a restrictive NAT/firewall and can't accept incoming
     /// packets from IPs that we haven't sent anything to.
     pub read_only: bool,
 }

--- a/src/dht/mod.rs
+++ b/src/dht/mod.rs
@@ -9,3 +9,5 @@ pub use dht_settings::*;
 pub mod dht_event;
 
 mod socket;
+
+pub mod operations;

--- a/src/dht/mod.rs
+++ b/src/dht/mod.rs
@@ -10,4 +10,5 @@ pub mod dht_event;
 
 mod socket;
 
+/// Functions that use [DHT](crate::dht::DHT) to perform high-level operations on the network.
 pub mod operations;

--- a/src/dht/operations.rs
+++ b/src/dht/operations.rs
@@ -1,4 +1,4 @@
-use crate::common::Id;
+use crate::common::{Id, Node};
 use crate::dht::DHT;
 use crate::packets;
 use crate::packets::MessageBuilder;
@@ -9,6 +9,103 @@ use log::{debug, error, info, trace, warn};
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
+
+/// Use the DHT to find the closes nodes to the target as possible.
+///
+/// This runs until it stops making progress or `timeout` has elapsed.
+pub async fn find_node(dht: &DHT, target: Id, timeout: Duration) -> Vec<Node> {
+    let mut buckets = Buckets::new(target, 8);
+    let dht_settings = dht.get_settings();
+
+    if let Err(_) = tokio::time::timeout(timeout, async {
+        let mut best_ids = Vec::new();
+        loop {
+            // Seed our buckets with the main buckets from the DHT
+            for node_wrapper in dht.get_nodes() {
+                if !buckets.contains(&node_wrapper.node.id) {
+                    buckets.add(node_wrapper, None);
+                }
+            }
+
+            // Grab a few nodes closest to our target
+            let nearest = buckets.get_nearest_nodes(&target, None);
+            if nearest.len() <= 0 {
+                // If there are no nodes in the buckets yet, DHT may still be bootstrapping. Give it a moment and try again
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+            let best_ids_current: Vec<Id> = nearest.iter().map(|nw| nw.node.id.clone()).collect();
+            if best_ids == best_ids_current {
+                break;
+            }
+            best_ids = best_ids_current;
+
+            // Get ready to send get_peers to all of those closest nodes
+            let request_builder = MessageBuilder::new_find_node_request()
+                .target(target)
+                .read_only(dht_settings.read_only)
+                .sender_id(dht.get_id());
+            let mut todos = futures::stream::FuturesUnordered::new();
+            for node in nearest {
+                todos.push(dht.send_request(
+                    request_builder
+                        .clone()
+                        .build()
+                        .expect("Failed to build find_node request"),
+                    node.node.address,
+                    Some(node.node.id),
+                    Some(Duration::from_secs(5))
+                ));
+            }
+
+            // Send get_peers to nearest nodes, handle their responses
+            let started_sending_time = Instant::now();
+            while let Some(request_result) = todos.next().await {
+                match request_result {
+                    Ok(message) => match message.message_type {
+                        packets::MessageType::Response(
+                            packets::ResponseSpecific::FindNodeResponse(args),
+                        ) => {
+                            for node in args.nodes {
+                                if !buckets.contains(&node.id) {
+                                    trace!(target: "rustydht_lib::operations::find_node", "Node {:?} is a candidate for buckets", node);
+                                    buckets.add(NodeWrapper::new(node), None);
+                                }
+                            }
+                        }
+
+                        _ => {
+                            error!(target: "rustydht_lib::operations::find_node", "Got wrong packet type back: {:?}", message);
+                        }
+                    },
+                    Err(e) => {
+                        warn!(target: "rustydht_lib::operations::find_node", "Error sending find_node request: {}", e);
+                    }
+                }
+            }
+
+            // Ensure that our next round of packet sending starts at least 1s from the last
+            // to prevent us from hitting other nodes too hard.
+            // i.e. don't be a jerk.
+            let since_sent = Instant::now().saturating_duration_since(started_sending_time);
+            let desired_interval = Duration::from_millis(1000);
+            let needed_sleep_interval = desired_interval.saturating_sub(since_sent);
+            if needed_sleep_interval != Duration::ZERO {
+                tokio::time::sleep(needed_sleep_interval).await;
+            }
+        }
+    })
+    .await
+    {
+        debug!(target: "rustydht_lib::operations::find_node", "Timed out after {:?}", timeout);
+    }
+
+    buckets
+        .get_nearest_nodes(&target, None)
+        .into_iter()
+        .map(|nw| nw.node.clone())
+        .collect()
+}
 
 /// Use the DHT to retrieve peers for the given info_hash.
 ///
@@ -27,9 +124,9 @@ pub async fn get_peers(
     if let Err(_) = tokio::time::timeout(timeout,
     async {
         while to_ret.len() < desired_peers {
-            // Prepopulate our buckets with the main buckets from the DHT
+            // Populate our buckets with the main buckets from the DHT
             for node_wrapper in dht.get_nodes() {
-                if let None = buckets.get_mut(&node_wrapper.node.id) {
+                if !buckets.contains(&node_wrapper.node.id) {
                     buckets.add(node_wrapper, None);
                 }
             }
@@ -66,8 +163,8 @@ pub async fn get_peers(
                             packets::GetPeersResponseValues::Nodes(n) => {
                                 debug!(target: "rustydht_lib::operations::get_peers", "Got {} nodes", n.len());
                                 for node in n {
-                                    if let None = buckets.get_mut(&node.id) {
-                                        trace!(target: "rustydht_lib::operations::get_peers", "Adding node {:?} to buckets", node);
+                                    if !buckets.contains(&node.id) {
+                                        trace!(target: "rustydht_lib::operations::get_peers", "Node {:?} is a candidate for buckets", node);
                                         buckets.add(NodeWrapper::new(node), None);
                                     }
                                 }

--- a/src/dht/operations.rs
+++ b/src/dht/operations.rs
@@ -1,0 +1,87 @@
+use crate::common::Id;
+use crate::dht::DHT;
+use crate::packets;
+use crate::storage::buckets::Buckets;
+use crate::storage::node_wrapper::NodeWrapper;
+use futures::StreamExt;
+use log::{debug, info, trace, warn};
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+pub async fn get_peers(dht: &DHT, info_hash: Id, min_peers: usize) -> Vec<SocketAddr> {
+    let mut to_ret = HashSet::new();
+
+    let mut buckets = Buckets::new(info_hash, 8);
+
+    while to_ret.len() < min_peers {
+        // Prepopulate our buckets with the main buckets from the DHT
+        for node_wrapper in dht.get_nodes() {
+            if let None = buckets.get_mut(&node_wrapper.node.id) {
+                buckets.add(node_wrapper, None);
+            }
+        }
+
+        // Grab a few nodes closest to our target info_hash
+        let nearest = buckets.get_nearest_nodes(&info_hash, None);
+
+        // Get ready to send get_peers to all of those closest nodes
+        let mut todos = futures::stream::FuturesUnordered::new();
+        for node in nearest {
+            let fut = tokio::time::timeout(
+                Duration::from_secs(10),
+                dht.send_get_peers(info_hash, node.node.address, Some(node.node.id)),
+            );
+            todos.push(fut);
+        }
+
+        // Send get_peers to nearest nodes, handle their responses
+        let started_sending_time = Instant::now();
+        while let Some(timeout_result) = todos.next().await {
+            if timeout_result.is_err() {
+                debug!(target: "rustydht_lib::operations::get_peers", "got tokio timeout: {}", timeout_result.unwrap_err());
+                continue;
+            }
+            let get_peers_result = timeout_result.unwrap();
+            if let Err(e) = get_peers_result {
+                warn!(target: "rustydht_lib::operations::get_peers", "Encountered error during get_peers: {}", e);
+                continue;
+            }
+
+            if let packets::MessageType::Response(packets::ResponseSpecific::GetPeersResponse(
+                args,
+            )) = get_peers_result.unwrap().message_type
+            {
+                match args.values {
+                    packets::GetPeersResponseValues::Nodes(n) => {
+                        trace!(target: "rustydht_lib::operations::get_peers", "Got {} nodes", n.len());
+                        for node in n {
+                            if let None = buckets.get_mut(&node.id) {
+                                info!(target: "rustydht_lib::operations::get_peers", "Adding node {:?} to buckets", node);
+                                buckets.add(NodeWrapper::new(node), None);
+                            }
+                        }
+                    }
+                    packets::GetPeersResponseValues::Peers(p) => {
+                        trace!(target: "rustydht_lib::operations::get_peers", "Got {} peers", p.len());
+                        for peer in p {
+                            to_ret.insert(peer);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Ensure that our next round of packet sending starts at least 2s from the last
+        // to prevent us from hitting other nodes too hard.
+        // i.e. don't be a jerk.
+        let since_sent = Instant::now().saturating_duration_since(started_sending_time);
+        let desired_interval = Duration::from_millis(2000);
+        let needed_sleep_interval = desired_interval.saturating_sub(since_sent);
+        if needed_sleep_interval != Duration::ZERO {
+            tokio::time::sleep(needed_sleep_interval).await;
+        }
+    }
+
+    to_ret.into_iter().collect()
+}

--- a/src/dht/operations.rs
+++ b/src/dht/operations.rs
@@ -10,6 +10,10 @@ use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
+/// Use the DHT to retrieve peers for the given info_hash.
+///
+/// This doesn't time out and will only return when it has
+/// found at least `min_peers` peers.
 pub async fn get_peers(dht: &DHT, info_hash: Id, min_peers: usize) -> Vec<SocketAddr> {
     let mut to_ret = HashSet::new();
     let mut buckets = Buckets::new(info_hash, 8);

--- a/src/dht/operations.rs
+++ b/src/dht/operations.rs
@@ -198,8 +198,8 @@ pub async fn find_node(
 
 /// Use the DHT to retrieve peers for the given info_hash.
 ///
-/// Returns the all the results so far after at least `desired_peers`
-/// peers have been found, or `timeout` has elapsed (whichever happens first)
+/// Returns the all the results so far after `timeout` has elapsed
+/// or the operation stops making progress (whichever happens first).
 pub async fn get_peers(
     dht: &DHT,
     info_hash: Id,

--- a/src/dht/operations.rs
+++ b/src/dht/operations.rs
@@ -12,93 +12,103 @@ use std::time::{Duration, Instant};
 
 /// Use the DHT to retrieve peers for the given info_hash.
 ///
-/// This doesn't time out and will only return when it has
-/// found at least `min_peers` peers.
-pub async fn get_peers(dht: &DHT, info_hash: Id, min_peers: usize) -> Vec<SocketAddr> {
+/// Returns the all the results so far after at least `desired_peers`
+/// peers have been found, or `timeout` has elapsed (whichever happens first)
+pub async fn get_peers(
+    dht: &DHT,
+    info_hash: Id,
+    desired_peers: usize,
+    timeout: Duration,
+) -> Vec<SocketAddr> {
     let mut to_ret = HashSet::new();
     let mut buckets = Buckets::new(info_hash, 8);
     let dht_settings = dht.get_settings();
 
-    while to_ret.len() < min_peers {
-        // Prepopulate our buckets with the main buckets from the DHT
-        for node_wrapper in dht.get_nodes() {
-            if let None = buckets.get_mut(&node_wrapper.node.id) {
-                buckets.add(node_wrapper, None);
+    if let Err(_) = tokio::time::timeout(timeout,
+    async {
+        while to_ret.len() < desired_peers {
+            // Prepopulate our buckets with the main buckets from the DHT
+            for node_wrapper in dht.get_nodes() {
+                if let None = buckets.get_mut(&node_wrapper.node.id) {
+                    buckets.add(node_wrapper, None);
+                }
             }
-        }
 
-        // Grab a few nodes closest to our target info_hash
-        let nearest = buckets.get_nearest_nodes(&info_hash, None);
+            // Grab a few nodes closest to our target info_hash
+            let nearest = buckets.get_nearest_nodes(&info_hash, None);
 
-        // Get ready to send get_peers to all of those closest nodes
-        let request_builder = MessageBuilder::new_get_peers_request()
-            .target(info_hash)
-            .read_only(dht_settings.read_only)
-            .sender_id(dht.get_id());
-        let mut todos = futures::stream::FuturesUnordered::new();
-        for node in nearest {
-            let fut = tokio::time::timeout(
-                Duration::from_secs(10),
-                dht.send_request(
-                    request_builder
-                        .clone()
-                        .build()
-                        .expect("Failed to build get_peers request"),
-                    node.node.address,
-                    Some(node.node.id),
-                ),
-            );
-            todos.push(fut);
-        }
+            // Get ready to send get_peers to all of those closest nodes
+            let request_builder = MessageBuilder::new_get_peers_request()
+                .target(info_hash)
+                .read_only(dht_settings.read_only)
+                .sender_id(dht.get_id());
+            let mut todos = futures::stream::FuturesUnordered::new();
+            for node in nearest {
+                let fut = tokio::time::timeout(
+                    Duration::from_secs(5),
+                    dht.send_request(
+                        request_builder
+                            .clone()
+                            .build()
+                            .expect("Failed to build get_peers request"),
+                        node.node.address,
+                        Some(node.node.id),
+                    ),
+                );
+                todos.push(fut);
+            }
 
-        // Send get_peers to nearest nodes, handle their responses
-        let started_sending_time = Instant::now();
-        while let Some(timeout_result) = todos.next().await {
-            match timeout_result {
-                Ok(request_result) => match request_result {
-                    Ok(message) => match message.message_type {
-                        packets::MessageType::Response(
-                            packets::ResponseSpecific::GetPeersResponse(args),
-                        ) => match args.values {
-                            packets::GetPeersResponseValues::Nodes(n) => {
-                                debug!(target: "rustydht_lib::operations::get_peers", "Got {} nodes", n.len());
-                                for node in n {
-                                    if let None = buckets.get_mut(&node.id) {
-                                        trace!(target: "rustydht_lib::operations::get_peers", "Adding node {:?} to buckets", node);
-                                        buckets.add(NodeWrapper::new(node), None);
+            // Send get_peers to nearest nodes, handle their responses
+            let started_sending_time = Instant::now();
+            while let Some(timeout_result) = todos.next().await {
+                match timeout_result {
+                    Ok(request_result) => match request_result {
+                        Ok(message) => match message.message_type {
+                            packets::MessageType::Response(
+                                packets::ResponseSpecific::GetPeersResponse(args),
+                            ) => match args.values {
+                                packets::GetPeersResponseValues::Nodes(n) => {
+                                    debug!(target: "rustydht_lib::operations::get_peers", "Got {} nodes", n.len());
+                                    for node in n {
+                                        if let None = buckets.get_mut(&node.id) {
+                                            trace!(target: "rustydht_lib::operations::get_peers", "Adding node {:?} to buckets", node);
+                                            buckets.add(NodeWrapper::new(node), None);
+                                        }
                                     }
                                 }
-                            }
-                            packets::GetPeersResponseValues::Peers(p) => {
-                                info!(target: "rustydht_lib::operations::get_peers", "Got {} peers", p.len());
-                                for peer in p {
-                                    to_ret.insert(peer);
+                                packets::GetPeersResponseValues::Peers(p) => {
+                                    info!(target: "rustydht_lib::operations::get_peers", "Got {} peers", p.len());
+                                    for peer in p {
+                                        to_ret.insert(peer);
+                                    }
                                 }
+                            },
+                            _ => {
+                                error!(target: "rustydht_lib::operations::get_peers", "Got wrong packet type back: {:?}", message);
                             }
                         },
-                        _ => {
-                            error!(target: "rustydht_lib::operations::get_peers", "Got wrong packet type back: {:?}", message);
+                        Err(e) => {
+                            warn!(target: "rustydht_lib::operations::get_peers", "Error sending get_peers request: {}", e);
                         }
                     },
                     Err(e) => {
-                        warn!(target: "rustydht_lib::operations::get_peers", "Error sending get_peers request: {}", e);
+                        debug!(target: "rustydht_lib::operations::get_peers", "get_peers request timed out: {}", e);
                     }
-                },
-                Err(e) => {
-                    debug!(target: "rustydht_lib::operations::get_peers", "get_peers request timed out: {}", e);
                 }
             }
-        }
 
-        // Ensure that our next round of packet sending starts at least 2s from the last
-        // to prevent us from hitting other nodes too hard.
-        // i.e. don't be a jerk.
-        let since_sent = Instant::now().saturating_duration_since(started_sending_time);
-        let desired_interval = Duration::from_millis(2000);
-        let needed_sleep_interval = desired_interval.saturating_sub(since_sent);
-        if needed_sleep_interval != Duration::ZERO {
-            tokio::time::sleep(needed_sleep_interval).await;
+            // Ensure that our next round of packet sending starts at least 1s from the last
+            // to prevent us from hitting other nodes too hard.
+            // i.e. don't be a jerk.
+            let since_sent = Instant::now().saturating_duration_since(started_sending_time);
+            let desired_interval = Duration::from_millis(1000);
+            let needed_sleep_interval = desired_interval.saturating_sub(since_sent);
+            if needed_sleep_interval != Duration::ZERO {
+                tokio::time::sleep(needed_sleep_interval).await;
+            }
         }
+    }).await {
+        debug!(target: "rustydht_lib::operations::get_peers", "Timed out after {:?}", timeout);
     }
 
     to_ret.into_iter().collect()

--- a/src/dht/operations.rs
+++ b/src/dht/operations.rs
@@ -1,18 +1,19 @@
 use crate::common::Id;
 use crate::dht::DHT;
 use crate::packets;
+use crate::packets::MessageBuilder;
 use crate::storage::buckets::Buckets;
 use crate::storage::node_wrapper::NodeWrapper;
 use futures::StreamExt;
-use log::{debug, info, trace, warn};
+use log::{debug, error, info, trace, warn};
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
 pub async fn get_peers(dht: &DHT, info_hash: Id, min_peers: usize) -> Vec<SocketAddr> {
     let mut to_ret = HashSet::new();
-
     let mut buckets = Buckets::new(info_hash, 8);
+    let dht_settings = dht.get_settings();
 
     while to_ret.len() < min_peers {
         // Prepopulate our buckets with the main buckets from the DHT
@@ -26,11 +27,22 @@ pub async fn get_peers(dht: &DHT, info_hash: Id, min_peers: usize) -> Vec<Socket
         let nearest = buckets.get_nearest_nodes(&info_hash, None);
 
         // Get ready to send get_peers to all of those closest nodes
+        let request_builder = MessageBuilder::new_get_peers_request()
+            .target(info_hash)
+            .read_only(dht_settings.read_only)
+            .sender_id(dht.get_id());
         let mut todos = futures::stream::FuturesUnordered::new();
         for node in nearest {
             let fut = tokio::time::timeout(
                 Duration::from_secs(10),
-                dht.send_get_peers(info_hash, node.node.address, Some(node.node.id)),
+                dht.send_request(
+                    request_builder
+                        .clone()
+                        .build()
+                        .expect("Failed to build get_peers request"),
+                    node.node.address,
+                    Some(node.node.id),
+                ),
             );
             todos.push(fut);
         }
@@ -38,36 +50,38 @@ pub async fn get_peers(dht: &DHT, info_hash: Id, min_peers: usize) -> Vec<Socket
         // Send get_peers to nearest nodes, handle their responses
         let started_sending_time = Instant::now();
         while let Some(timeout_result) = todos.next().await {
-            if timeout_result.is_err() {
-                debug!(target: "rustydht_lib::operations::get_peers", "got tokio timeout: {}", timeout_result.unwrap_err());
-                continue;
-            }
-            let get_peers_result = timeout_result.unwrap();
-            if let Err(e) = get_peers_result {
-                warn!(target: "rustydht_lib::operations::get_peers", "Encountered error during get_peers: {}", e);
-                continue;
-            }
-
-            if let packets::MessageType::Response(packets::ResponseSpecific::GetPeersResponse(
-                args,
-            )) = get_peers_result.unwrap().message_type
-            {
-                match args.values {
-                    packets::GetPeersResponseValues::Nodes(n) => {
-                        trace!(target: "rustydht_lib::operations::get_peers", "Got {} nodes", n.len());
-                        for node in n {
-                            if let None = buckets.get_mut(&node.id) {
-                                info!(target: "rustydht_lib::operations::get_peers", "Adding node {:?} to buckets", node);
-                                buckets.add(NodeWrapper::new(node), None);
+            match timeout_result {
+                Ok(request_result) => match request_result {
+                    Ok(message) => match message.message_type {
+                        packets::MessageType::Response(
+                            packets::ResponseSpecific::GetPeersResponse(args),
+                        ) => match args.values {
+                            packets::GetPeersResponseValues::Nodes(n) => {
+                                debug!(target: "rustydht_lib::operations::get_peers", "Got {} nodes", n.len());
+                                for node in n {
+                                    if let None = buckets.get_mut(&node.id) {
+                                        trace!(target: "rustydht_lib::operations::get_peers", "Adding node {:?} to buckets", node);
+                                        buckets.add(NodeWrapper::new(node), None);
+                                    }
+                                }
                             }
+                            packets::GetPeersResponseValues::Peers(p) => {
+                                info!(target: "rustydht_lib::operations::get_peers", "Got {} peers", p.len());
+                                for peer in p {
+                                    to_ret.insert(peer);
+                                }
+                            }
+                        },
+                        _ => {
+                            error!(target: "rustydht_lib::operations::get_peers", "Got wrong packet type back: {:?}", message);
                         }
+                    },
+                    Err(e) => {
+                        warn!(target: "rustydht_lib::operations::get_peers", "Error sending get_peers request: {}", e);
                     }
-                    packets::GetPeersResponseValues::Peers(p) => {
-                        trace!(target: "rustydht_lib::operations::get_peers", "Got {} peers", p.len());
-                        for peer in p {
-                            to_ret.insert(peer);
-                        }
-                    }
+                },
+                Err(e) => {
+                    debug!(target: "rustydht_lib::operations::get_peers", "get_peers request timed out: {}", e);
                 }
             }
         }

--- a/src/dht/operations.rs
+++ b/src/dht/operations.rs
@@ -5,7 +5,6 @@ use crate::packets;
 use crate::packets::MessageBuilder;
 use crate::storage::buckets::Buckets;
 use crate::storage::node_wrapper::NodeWrapper;
-use anyhow::anyhow;
 use futures::StreamExt;
 use log::{debug, error, info, trace, warn};
 use std::collections::HashSet;
@@ -33,18 +32,43 @@ pub async fn announce_peer(
     let mut to_ret = Vec::new();
 
     // Figure out which nodes we want to announce to
-    let nodes = find_node(dht, info_hash, timeout).await;
+    let get_peers_result = get_peers(dht, info_hash, timeout).await;
 
-    // Prepare to send packets to all of them
+    trace!(target:"rustydht_lib::operations::announce_peer", "{} nodes responded to get_peers", get_peers_result.responders.len());
+
+    let announce_builder = MessageBuilder::new_announce_peer_request()
+        .sender_id(dht.get_id())
+        .read_only(dht.get_settings().read_only)
+        .target(info_hash)
+        .port(match port {
+            Some(p) => p,
+            None => 0,
+        })
+        .implied_port(match port {
+            Some(_) => false,
+            None => true,
+        });
+
+    // Prepare to send packets to the nearest 8
     let mut todos = futures::stream::FuturesUnordered::new();
-    for node in nodes {
+    for responder in get_peers_result.responders.into_iter().take(8) {
+        let builder = announce_builder.clone();
         todos.push(async move {
-            match get_peers_then_announce(dht, info_hash, port, node.address, Some(node.id), Some(Duration::from_secs(5))).await {
-                Ok(_) => Some(node),
-                Err(e) => {
-                    debug!(target: "rustydht_lib::operations::announce_peer", "Failed to announce to {:?}. Error: {}", node, e);
-                    None
-                }
+            let announce_req = builder
+                .token(responder.token)
+                .build()
+                .expect("Failed to build announce_peer request");
+            match dht
+                .send_request(
+                    announce_req,
+                    responder.node.address,
+                    Some(responder.node.id),
+                    Some(Duration::from_secs(5)),
+                )
+                .await
+            {
+                Ok(_) => Ok(responder.node),
+                Err(e) => Err(e),
             }
         });
     }
@@ -52,10 +76,19 @@ pub async fn announce_peer(
     // Execute the futures, handle their results
     while let Some(announce_result) = todos.next().await {
         match announce_result {
-            Some(node) => {
+            Ok(node) => {
                 to_ret.push(node);
             }
-            _ => {}
+
+            Err(e) => match e {
+                RustyDHTError::TimeoutError(_) => {
+                    debug!(target: "rustydht_lib::operations::announce_peer", "announce_peer timed out: {}", e);
+                }
+
+                _ => {
+                    warn!(target: "rustydht_lib::operations::announce_peer", "Error sending announce_peer: {}", e);
+                }
+            },
         }
     }
 
@@ -163,19 +196,19 @@ pub async fn find_node(dht: &DHT, target: Id, timeout: Duration) -> Vec<Node> {
 ///
 /// Returns the all the results so far after at least `desired_peers`
 /// peers have been found, or `timeout` has elapsed (whichever happens first)
-pub async fn get_peers(
-    dht: &DHT,
-    info_hash: Id,
-    desired_peers: usize,
-    timeout: Duration,
-) -> Vec<SocketAddr> {
-    let mut to_ret = HashSet::new();
+pub async fn get_peers(dht: &DHT, info_hash: Id, timeout: Duration) -> GetPeersResult {
+    let mut unique_peers = HashSet::new();
+    let mut responders = Vec::new();
     let mut buckets = Buckets::new(info_hash, 8);
     let dht_settings = dht.get_settings();
 
+    // Hack to aid in bootstrapping
+    find_node(dht, info_hash, Duration::from_secs(5)).await;
+
     if let Err(_) = tokio::time::timeout(timeout,
     async {
-        while to_ret.len() < desired_peers {
+        let mut best_ids = Vec::new();
+        loop {
             // Populate our buckets with the main buckets from the DHT
             for node_wrapper in dht.get_nodes() {
                 if !buckets.contains(&node_wrapper.node.id) {
@@ -185,6 +218,16 @@ pub async fn get_peers(
 
             // Grab a few nodes closest to our target info_hash
             let nearest = buckets.get_nearest_nodes(&info_hash, None);
+            if nearest.len() <= 5 {
+                // If there are no/few nodes in the buckets yet, DHT may still be bootstrapping. Give it a moment and try again
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+            let best_ids_current: Vec<Id> = nearest.iter().map(|nw| nw.node.id.clone()).collect();
+            if best_ids == best_ids_current {
+                break;
+            }
+            best_ids = best_ids_current;
 
             // Get ready to send get_peers to all of those closest nodes
             let request_builder = MessageBuilder::new_get_peers_request()
@@ -193,25 +236,37 @@ pub async fn get_peers(
                 .sender_id(dht.get_id());
             let mut todos = futures::stream::FuturesUnordered::new();
             for node in nearest {
-                todos.push(dht.send_request(
-                    request_builder
-                        .clone()
-                        .build()
-                        .expect("Failed to build get_peers request"),
-                    node.node.address,
-                    Some(node.node.id),
-                    Some(Duration::from_secs(5))
-                ));
+                let node_clone = node.clone();
+                let request_builder_clone = request_builder.clone();
+                todos.push(async move {
+                    match dht.send_request(
+                        request_builder_clone
+                            .build()
+                            .expect("Failed to build get_peers request"),
+                        node_clone.node.address,
+                        Some(node_clone.node.id),
+                        Some(Duration::from_secs(5))
+                    ).await {
+                        Ok(reply) => Ok((node_clone.node, reply)),
+                        Err(e) => Err(e)
+                    }
+                });
             }
 
             // Send get_peers to nearest nodes, handle their responses
             let started_sending_time = Instant::now();
             while let Some(request_result) = todos.next().await {
                 match request_result {
-                    Ok(message) => match message.message_type {
+                    Ok(result) => match result.1.message_type {
                         packets::MessageType::Response(
                             packets::ResponseSpecific::GetPeersResponse(args),
-                        ) => match args.values {
+                        ) => {
+                            responders.push(GetPeersResponder{
+                                node: result.0,
+                                token: args.token
+                            });
+
+                            match args.values {
                             packets::GetPeersResponseValues::Nodes(n) => {
                                 debug!(target: "rustydht_lib::operations::get_peers", "Got {} nodes", n.len());
                                 for node in n {
@@ -224,12 +279,12 @@ pub async fn get_peers(
                             packets::GetPeersResponseValues::Peers(p) => {
                                 info!(target: "rustydht_lib::operations::get_peers", "Got {} peers", p.len());
                                 for peer in p {
-                                    to_ret.insert(peer);
+                                    unique_peers.insert(peer);
                                 }
                             }
-                        },
+                        }},
                         _ => {
-                            error!(target: "rustydht_lib::operations::get_peers", "Got wrong packet type back: {:?}", message);
+                            error!(target: "rustydht_lib::operations::get_peers", "Got wrong packet type back: {:?}", result.1);
                         }
                     },
                     Err(e) => {
@@ -249,57 +304,38 @@ pub async fn get_peers(
             }
         }
     }).await {
-        debug!(target: "rustydht_lib::operations::get_peers", "Timed out after {:?}", timeout);
+        debug!(target: "rustydht_lib::operations::get_peers", "Timed out after {:?}, returning current results", timeout);
     }
 
-    to_ret.into_iter().collect()
+    GetPeersResult::new(info_hash, unique_peers.into_iter().collect(), responders)
 }
 
-async fn get_peers_then_announce(
-    dht: &DHT,
-    info_hash: Id,
-    port: Option<u16>,
-    dest: SocketAddr,
-    dest_id: Option<Id>,
-    timeout: Option<Duration>,
-) -> Result<(), RustyDHTError> {
-    let dht_settings = dht.get_settings();
-    let our_id = dht.get_id();
-    let get_peers_req = MessageBuilder::new_get_peers_request()
-        .sender_id(our_id)
-        .read_only(dht_settings.read_only)
-        .target(info_hash)
-        .build()?;
+pub struct GetPeersResult {
+    pub info_hash: Id,
+    pub peers: Vec<SocketAddr>,
+    pub responders: Vec<GetPeersResponder>,
+}
 
-    let get_peers_reply = dht
-        .send_request(get_peers_req, dest, dest_id, timeout)
-        .await?;
-
-    match get_peers_reply.message_type {
-        packets::MessageType::Response(packets::ResponseSpecific::GetPeersResponse(args)) => {
-            let announce_peers_req = MessageBuilder::new_announce_peer_request()
-                .sender_id(our_id)
-                .read_only(dht_settings.read_only)
-                .target(info_hash)
-                .token(args.token)
-                .port(match port {
-                    Some(p) => p,
-                    None => 0,
-                })
-                .implied_port(match port {
-                    Some(_) => false,
-                    None => true,
-                })
-                .build()?;
-
-            dht.send_request(announce_peers_req, dest, dest_id, timeout)
-                .await?;
-
-            // If we don't get an error from the announce_peer send_request, then we got a good response
-            Ok(())
+impl GetPeersResult {
+    pub fn new(
+        info_hash: Id,
+        peers: Vec<SocketAddr>,
+        mut responders: Vec<GetPeersResponder>,
+    ) -> GetPeersResult {
+        responders.sort_unstable_by(|a, b| {
+            let a_dist = a.node.id.xor(&info_hash);
+            let b_dist = b.node.id.xor(&info_hash);
+            a_dist.partial_cmp(&b_dist).unwrap()
+        });
+        GetPeersResult {
+            info_hash: info_hash,
+            peers: peers,
+            responders: responders,
         }
-        _ => Err(RustyDHTError::GeneralError(anyhow!(
-            "Received wrong response to get_peers"
-        ))),
     }
+}
+
+pub struct GetPeersResponder {
+    pub node: Node,
+    pub token: Vec<u8>,
 }

--- a/src/dht/socket.rs
+++ b/src/dht/socket.rs
@@ -174,28 +174,50 @@ impl DHTSocket {
         trace!(target:"rustydht_lib::DHTSocket", "Receiving {} bytes from {}", num_bytes, sender);
         let message = packets::Message::from_bytes(&buf[..num_bytes])?;
 
-        let request_info = {
-            request_storage
-                .lock()
-                .unwrap()
-                .take_matching_request_info(&message, sender)
-        };
-        // Is this message a reply to something we sent? If so, notify via specific channel
-        if let Some(request_info) = request_info {
-            if let Some(response_channel) = request_info.response_channel {
-                if let Err(e) = response_channel.send(message.clone()).await {
-                    let message = e.0;
-                    warn!(target: "rustydht_lib::DHTSocket", "Got response, but sending code abandoned the channel receiver. So sad. Response: {:?}. Sender: {:?}", message, sender);
+        match message.message_type {
+            packets::MessageType::Response(_) => {
+                let request_info = {
+                    request_storage
+                        .lock()
+                        .unwrap()
+                        .take_matching_request_info(&message, sender)
+                };
+
+                match request_info {
+                    Some(request_info) => {
+                        match request_info.response_channel {
+                            Some(response_channel) => {
+                                if let Err(e) = response_channel.send(message.clone()).await {
+                                    let message = e.0;
+                                    warn!(target: "rustydht_lib::DHTSocket", "Got response, but sending code abandoned the channel receiver. So sad. Response: {:?}. Sender: {:?}", message, sender);
+                                }
+                            }
+                            None => { /*It's fine if there's no channel - just means that the sender didn't care about getting a response*/
+                            }
+                        }
+
+                        // Since the response is to a valid request, send it to the general recv channel
+                        recv_from_tx
+                            .send((message, sender))
+                            .await
+                            .map_err(|e| RustyDHTError::GeneralError(e.into()))?;
+                    }
+
+                    None => {
+                        warn!(target: "rusydht_lib::DHTSocket", "Received spurious response {:?} from {}", message, sender);
+                    }
                 }
-            } else {
-                warn!(target: "rustydht_lib::DHTSocket", "Got response, but can't notify due to no channel. I should make channel required. Response: {:?}. Sender: {:?}", message, sender);
             }
-        }
-        // Always send it to the generic recv_from channel
-        recv_from_tx
-            .send((message, sender))
-            .await
-            .map_err(|e| RustyDHTError::GeneralError(e.into()))?;
+
+            _ => {
+                // Request and Error messages always get sent to the general recv channel
+                recv_from_tx
+                    .send((message, sender))
+                    .await
+                    .map_err(|e| RustyDHTError::GeneralError(e.into()))?;
+            }
+        };
+
         Ok(())
     }
 

--- a/src/dht/socket.rs
+++ b/src/dht/socket.rs
@@ -67,8 +67,6 @@ impl DHTSocket {
         dest: SocketAddr,
         dest_id: Option<Id>,
     ) -> Result<Option<mpsc::Receiver<packets::Message>>, RustyDHTError> {
-        trace!(target: "rustydht_lib::DHTSocket", "Caller wants to send_to {:?} to {}", to_send, dest);
-
         let mut to_ret = None;
         // optimization to only store notification stuff on requests (not on replies too)
         if let packets::MessageType::Request(_) = to_send.message_type {
@@ -173,8 +171,8 @@ impl DHTSocket {
             .recv_from(&mut buf)
             .await
             .map_err(|e| RustyDHTError::SocketRecvError(e.into()))?;
+        trace!(target:"rustydht_lib::DHTSocket", "Receiving {} bytes from {}", num_bytes, sender);
         let message = packets::Message::from_bytes(&buf[..num_bytes])?;
-        trace!(target:"rustydht_lib::DHTSocket", "Receiving {:?} from {}", message, sender);
 
         let request_info = {
             request_storage

--- a/src/packets/builder.rs
+++ b/src/packets/builder.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 ///     .build()
 ///     .unwrap();
 /// ```
+#[derive(Clone)]
 pub struct MessageBuilder {
     message_type: BuilderMessageType,
 
@@ -52,6 +53,7 @@ pub struct MessageBuilder {
 }
 
 /// All the different types of Message that a MesssageBuilder can build
+#[derive(Clone)]
 enum BuilderMessageType {
     PingRequest,
     PingResponse,

--- a/src/packets/public.rs
+++ b/src/packets/public.rs
@@ -561,6 +561,11 @@ pub fn response_matches_request(res: &ResponseSpecific, req: &RequestSpecific) -
             if let RequestSpecific::PingRequest { .. } = req {
                 return true;
             }
+
+            // Ping responses are indistinguishable from announce_peer responses
+            if let RequestSpecific::AnnouncePeerRequest { .. } = req {
+                return true;
+            }
         }
 
         ResponseSpecific::FindNodeResponse { .. } => {
@@ -571,6 +576,12 @@ pub fn response_matches_request(res: &ResponseSpecific, req: &RequestSpecific) -
 
         ResponseSpecific::GetPeersResponse { .. } => {
             if let RequestSpecific::GetPeersRequest { .. } = req {
+                return true;
+            }
+        }
+
+        ResponseSpecific::SampleInfoHashesResponse { .. } => {
+            if let RequestSpecific::SampleInfoHashesRequest { .. } = req {
                 return true;
             }
         }

--- a/src/packets/public.rs
+++ b/src/packets/public.rs
@@ -2,7 +2,6 @@ use super::internal;
 use crate::common::{Id, Node, ID_SIZE};
 use crate::errors;
 use anyhow::anyhow;
-use log::warn;
 use std::convert::TryInto;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
@@ -584,13 +583,6 @@ pub fn response_matches_request(res: &ResponseSpecific, req: &RequestSpecific) -
             if let RequestSpecific::SampleInfoHashesRequest { .. } = req {
                 return true;
             }
-        }
-
-        _ => {
-            warn!(target: "rustydht_lib::response_matches_request",
-                "Unimplemented response type {:?}",
-                res
-            );
         }
     }
     return false;

--- a/src/packets/public.rs
+++ b/src/packets/public.rs
@@ -522,6 +522,13 @@ impl Message {
         Message::from_serde_message(internal::DHTMessage::from_bytes(bytes)?)
     }
 
+    /// Return the Id of the sender of the Message
+    ///
+    /// This is less straightforward than it seems because not *all* messages are sent
+    /// with an Id (all are except Error messages). This is reflected in the structure
+    /// of DHT Messages, and makes it a bit annoying to learn the sender's Id without
+    /// unraveling the entire message. This method is a convenience method to extract
+    /// the sender (or "author") Id from the guts of any Message.
     pub fn get_author_id(&self) -> Option<Id> {
         let id = match &self.message_type {
             MessageType::Request(request_variant) => match request_variant {

--- a/src/packets/public.rs
+++ b/src/packets/public.rs
@@ -485,13 +485,13 @@ impl Message {
         return Some(id);
     }
 
-    pub fn create_ping_request(requester_id: Id) -> Message {
+    pub fn create_ping_request(requester_id: Id, read_only: bool) -> Message {
         let mut rng = thread_rng();
         Message {
             transaction_id: vec![rng.gen(), rng.gen()],
             version: None,
             requester_ip: None,
-            read_only: None,
+            read_only: if read_only { Some(true) } else { None },
             message_type: MessageType::Request(RequestSpecific::PingRequest(
                 PingRequestArguments {
                     requester_id: requester_id,
@@ -517,13 +517,13 @@ impl Message {
         }
     }
 
-    pub fn create_get_peers_request(requester_id: Id, info_hash: Id) -> Message {
+    pub fn create_get_peers_request(requester_id: Id, info_hash: Id, read_only: bool) -> Message {
         let mut rng = thread_rng();
         Message {
             transaction_id: vec![rng.gen(), rng.gen()],
             version: None,
             requester_ip: None,
-            read_only: None,
+            read_only: if read_only { Some(true) } else { None },
             message_type: MessageType::Request(RequestSpecific::GetPeersRequest(
                 GetPeersRequestArguments {
                     requester_id: requester_id,
@@ -577,13 +577,13 @@ impl Message {
         }
     }
 
-    pub fn create_find_node_request(requester_id: Id, target: Id) -> Message {
+    pub fn create_find_node_request(requester_id: Id, target: Id, read_only: bool) -> Message {
         let mut rng = thread_rng();
         Message {
             transaction_id: vec![rng.gen(), rng.gen()],
             version: None,
             requester_ip: None,
-            read_only: None,
+            read_only: if read_only { Some(true) } else { None },
             message_type: MessageType::Request(RequestSpecific::FindNodeRequest(
                 FindNodeRequestArguments {
                     requester_id: requester_id,
@@ -693,6 +693,12 @@ pub fn response_matches_request(res: &ResponseSpecific, req: &RequestSpecific) -
 
         ResponseSpecific::FindNodeResponse { .. } => {
             if let RequestSpecific::FindNodeRequest { .. } = req {
+                return true;
+            }
+        }
+
+        ResponseSpecific::GetPeersResponse { .. } => {
+            if let RequestSpecific::GetPeersRequest { .. } = req {
                 return true;
             }
         }

--- a/src/storage/buckets.rs
+++ b/src/storage/buckets.rs
@@ -82,6 +82,9 @@ impl<T: Bucketable> Buckets<T> {
         None
     }
 
+    /// Get the `k` nearest nodes/items stored in the buckets
+    ///
+    /// The returned vector is sorted by distance, from nearest to farthest.
     pub fn get_nearest_nodes(&self, id: &Id, exclude: Option<&Id>) -> Vec<&T> {
         let mut all: Vec<&T> = self
             .values()

--- a/src/storage/buckets.rs
+++ b/src/storage/buckets.rs
@@ -45,6 +45,18 @@ impl<T: Bucketable> Buckets<T> {
         self.buckets.push(Vec::with_capacity(2 * self.k));
     }
 
+    pub fn contains(&self, id: &Id) -> bool {
+        let dest_bucket_idx = self.get_dest_bucket_idx_for_id(&id);
+        if let Some(bucket) = self.buckets.get(dest_bucket_idx) {
+            for item in bucket.iter() {
+                if item.get_id() == *id {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     pub fn count(&self) -> usize {
         let mut count = 0;
         for bucket in &self.buckets {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,4 @@
-mod buckets;
+pub mod buckets;
 pub mod node_bucket_storage;
 pub mod node_wrapper;
 pub mod outbound_request_storage;

--- a/src/storage/outbound_request_storage.rs
+++ b/src/storage/outbound_request_storage.rs
@@ -146,7 +146,7 @@ mod tests {
         let mut storage = OutboundRequestStorage::new();
 
         let our_id = Id::from_hex("0000000000000000000000000000000000000000").unwrap();
-        let req = Message::create_ping_request(our_id);
+        let req = Message::create_ping_request(our_id, false);
 
         let request_target_addr = "127.0.0.1:1234".parse().unwrap();
         let request_info = RequestInfo::new(request_target_addr, None, req.clone(), None);
@@ -186,8 +186,8 @@ mod tests {
         let mut storage = OutboundRequestStorage::new();
 
         let our_id = Id::from_hex("0000000000000000000000000000000000000000").unwrap();
-        let req = Message::create_ping_request(our_id);
-        let req_2 = Message::create_ping_request(our_id);
+        let req = Message::create_ping_request(our_id, false);
+        let req_2 = Message::create_ping_request(our_id, false);
 
         let request_info =
             RequestInfo::new("127.0.0.1:1234".parse().unwrap(), None, req.clone(), None);


### PR DESCRIPTION
Add easy high-level public implementations of common DHT tasks such as

- [x] retrieving a set of peers for a given info_hash
- [x] announcing to an info_hash
- [x] finding a node
- [x] pinging a node