### PR TITLE
Tie dht_node example's help metadata to the crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed DHT behavior in read-only mode. It will no longer respond to requests in read-only mode.
 * Fix `dht_node` example invocation in README.md
 * Refactor common DHT request handling code into a common method.
+* Change `dht_node` example's 'authors' and 'version' help metadata to be tied to the crate.
 
 ## [v2.0.1] - 2022-01-01
 * Fix a Windows-only bug that can cause DHTSocket to error if someone sends it a datagram larger than the receive buffer.

--- a/examples/dht_node.rs
+++ b/examples/dht_node.rs
@@ -26,9 +26,9 @@ async fn main() {
         .expect("Failed to initialize logging");
 
     let matches = App::new("dht_node")
-        .version("0.1")
-        .author("raptorswing")
-        .about("Example application for rustydht-lib. Acts as a Node on the mainline BitTorrent DHT network, runs a small HTTP status page.")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about("Example application for rustydht-lib. Acts as a Node on the mainline BitTorrent DHT network, and runs a small HTTP status page.")
         .arg(
             Arg::with_name("listen_port")
             .short("l")


### PR DESCRIPTION
So that when running --help it will use the version from the crate.