### PR TITLE
Use Mutex::lock() instead of Mutex::try_lock()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # rustydht-lib changelog
 
+## [Unreleased]
+* Fix incompatibility between the code and multithreading. Use `Mutex::lock()` instead of `Mutex::try_lock()`. This was a relic from debugging locking.
+
 ## [v3.0.0] - 2022-01-12
 * Add a `DHTBuilder` for more easily constructing DHT objects. Add a `DHTSettingsBuilder` for more easily constructing DHTSettings objects. Revise `DHT::new()` (this is a breaking change to the public API).
 * Remove `count_buckets` method from `NodeStorage` trait. This was an implementation detail of bucket-based storage leaking into the trait, which should be more generic. This is a breaking change to the public API.
@@ -23,6 +26,7 @@
 * Add MessageBuilder, a fluent interface for building Message structs. Remove the old create_ methods for creating Messages. This change makes breaking changes to the public API, and is the reason for the major version bump.
 * Add an example called `dht_node` to the examples/ folder. It runs a DHT node and provides a simple HTTP status page.
 
+[Unreleased]: https://github.com/raptorswing/rustydht-lib/compare/v3.0.0...main
 [v3.0.0]: https://github.com/raptorswing/rustydht-lib/compare/v2.1.0...v3.0.0
 [v2.1.0]: https://github.com/raptorswing/rustydht-lib/compare/v2.0.1...v2.1.0
 [v2.0.1]: https://github.com/raptorswing/rustydht-lib/compare/v2.0.0...v2.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ serde = { version = "1.0.133", features = ["derive"] }
 serde_bytes = "0.11.5"
 serde_derive = "1.0.133"
 thiserror = "1.0.30"
-tokio = { version = "1.15.0", features = ["rt","net", "time", "macros", "sync"] }
+tokio = { version = "1.15.0", features = ["rt-multi-thread","net", "time", "macros", "sync"] }
 
 [dev-dependencies]
 clap = "2.34.0"
 rand_chacha = "0.3.0"
 simple_logger = { version = "1.16.0", default-features = false, features = ["colors"] }
-tokio = { version = "1.15.0", features = ["rt","net", "time", "macros", "sync", "signal"] }
+tokio = { version = "1.15.0", features = ["rt-multi-thread","net", "time", "macros", "sync", "signal"] }
 warp = "0.3.2"

--- a/examples/announce_peer.rs
+++ b/examples/announce_peer.rs
@@ -9,7 +9,7 @@ use std::net::{Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 use std::time::Duration;
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() {
     SimpleLogger::new()
         .with_level(LevelFilter::Warn)

--- a/examples/dht_node.rs
+++ b/examples/dht_node.rs
@@ -10,7 +10,7 @@ use std::net::{Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 use warp::Filter;
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() {
     SimpleLogger::new()
         .with_level(LevelFilter::Error)

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -9,7 +9,7 @@ use std::net::{Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 use std::time::Duration;
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() {
     SimpleLogger::new()
         .with_level(LevelFilter::Warn)

--- a/examples/get_peers.rs
+++ b/examples/get_peers.rs
@@ -9,7 +9,7 @@ use std::net::{Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 use std::time::Duration;
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() {
     SimpleLogger::new()
         .with_level(LevelFilter::Warn)


### PR DESCRIPTION
This fixes a bug that caused the library to crash when running with tokio's (default) `rt-multi-thread` runtime.