### PR TITLE
Fix clippy warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # rustydht-lib changelog
 
+## [Unreleased]
+* Cleanup clippy lint findings. Thanks RRRadicalEdward! This change adds to the public API, but doesn't change existing public API.
+
 ## [v3.0.1] - 2022-01-16
 * Fix incompatibility between the code and multithreading. Use `Mutex::lock()` instead of `Mutex::try_lock()`. This was a relic from debugging locking.
 
@@ -26,6 +29,7 @@
 * Add MessageBuilder, a fluent interface for building Message structs. Remove the old create_ methods for creating Messages. This change makes breaking changes to the public API, and is the reason for the major version bump.
 * Add an example called `dht_node` to the examples/ folder. It runs a DHT node and provides a simple HTTP status page.
 
+[Unreleased]: https://github.com/raptorswing/rustydht-lib/compare/v3.0.1...main
 [v3.0.1]: https://github.com/raptorswing/rustydht-lib/compare/v3.0.0...v3.0.1
 [v3.0.0]: https://github.com/raptorswing/rustydht-lib/compare/v2.1.0...v3.0.0
 [v2.1.0]: https://github.com/raptorswing/rustydht-lib/compare/v2.0.1...v2.1.0

--- a/examples/announce_peer.rs
+++ b/examples/announce_peer.rs
@@ -56,7 +56,7 @@ async fn main() {
         .expect("Invalid value for listen port");
 
     let info_hash = Id::from_hex(
-        &cmdline_matches
+        cmdline_matches
             .value_of("info_hash")
             .expect("No value specified for info_hash"),
     )

--- a/examples/dht_node.rs
+++ b/examples/dht_node.rs
@@ -56,7 +56,7 @@ async fn main() {
 
     if let Some(arg) = matches.value_of("initial_id") {
         builder = builder.initial_id(
-            rustydht_lib::common::Id::from_hex(&arg).expect("Failed to parse initial_id into Id"),
+            rustydht_lib::common::Id::from_hex(arg).expect("Failed to parse initial_id into Id"),
         );
     }
 

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -49,7 +49,7 @@ async fn main() {
         .expect("Invalid value for listen port");
 
     let info_hash = Id::from_hex(
-        &cmdline_matches
+        cmdline_matches
             .value_of("info_hash")
             .expect("No value specified for info_hash"),
     )

--- a/examples/get_peers.rs
+++ b/examples/get_peers.rs
@@ -49,7 +49,7 @@ async fn main() {
         .expect("Invalid value for listen port");
 
     let info_hash = Id::from_hex(
-        &cmdline_matches
+        cmdline_matches
             .value_of("info_hash")
             .expect("No value specified for info_hash"),
     )

--- a/src/common/id.rs
+++ b/src/common/id.rs
@@ -126,7 +126,7 @@ impl Id {
     /// Example: `let distance_between_nodes = id.xor(other_id);`
     pub fn xor(&self, other: &Id) -> Id {
         let mut bytes: [u8; ID_SIZE] = [0; ID_SIZE];
-        for (i, item ) in  bytes.iter_mut().enumerate().take(ID_SIZE) {
+        for (i, item) in bytes.iter_mut().enumerate().take(ID_SIZE) {
             *item = self.bytes[i] ^ other.bytes[i];
         }
 
@@ -172,9 +172,9 @@ impl PartialOrd for Id {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         for i in 0..self.bytes.len() {
             match self.bytes[i].cmp(&other.bytes[i]) {
-                 std::cmp::Ordering::Less =>  return Some(std::cmp::Ordering::Less),
-                 std::cmp::Ordering::Greater => return Some(std::cmp::Ordering::Greater),
-                 _ => continue,
+                std::cmp::Ordering::Less => return Some(std::cmp::Ordering::Less),
+                std::cmp::Ordering::Greater => return Some(std::cmp::Ordering::Greater),
+                _ => continue,
             };
         }
 
@@ -237,7 +237,7 @@ impl IdPrefixMagic {
 
 impl PartialEq for IdPrefixMagic {
     fn eq(&self, other: &Self) -> bool {
-       self.prefix[0] == other.prefix[0]
+        self.prefix[0] == other.prefix[0]
             && self.prefix[1] == other.prefix[1]
             && self.prefix[2] & 0xf8 == other.prefix[2] & 0xf8
             && self.suffix == other.suffix
@@ -308,17 +308,26 @@ mod tests {
         let h1 = Id::from_hex("0000000000000000000000000000000000000001").unwrap();
         let h2 = Id::from_hex("0000000000000000000000000000000000000001").unwrap();
         let h3 = h1.xor(&h2);
-        assert_eq!(h3, Id::from_hex("0000000000000000000000000000000000000000").unwrap());
+        assert_eq!(
+            h3,
+            Id::from_hex("0000000000000000000000000000000000000000").unwrap()
+        );
 
         let h1 = Id::from_hex("1010101010101010101010101010101010101010").unwrap();
         let h2 = Id::from_hex("0101010101010101010101010101010101010101").unwrap();
         let h3 = h1.xor(&h2);
-        assert_eq!(h3, Id::from_hex("1111111111111111111111111111111111111111").unwrap());
+        assert_eq!(
+            h3,
+            Id::from_hex("1111111111111111111111111111111111111111").unwrap()
+        );
 
         let h1 = Id::from_hex("fefefefefefefefefefefefefefefefefefefefe").unwrap();
         let h2 = Id::from_hex("0505050505050505050505050505050505050505").unwrap();
         let h3 = h1.xor(&h2);
-        assert_eq!(h3, Id::from_hex("fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb").unwrap());
+        assert_eq!(
+            h3,
+            Id::from_hex("fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb").unwrap()
+        );
     }
 
     #[test]

--- a/src/common/id.rs
+++ b/src/common/id.rs
@@ -15,7 +15,7 @@ pub const ID_SIZE: usize = 20;
 
 /// Represents the id of a [Node](crate::common::Node) or a BitTorrent info-hash. Basically, it's a
 /// 20-byte identifier.
-#[derive(Eq, PartialEq, Copy, Clone)]
+#[derive(Eq, PartialEq, Hash, Copy, Clone)]
 pub struct Id {
     bytes: [u8; ID_SIZE],
 }
@@ -32,9 +32,7 @@ impl Id {
         }
 
         let mut tmp: [u8; ID_SIZE] = [0; ID_SIZE];
-        for i in 0..ID_SIZE {
-            tmp[i] = bytes[i];
-        }
+        tmp[..ID_SIZE].clone_from_slice(&bytes[..ID_SIZE]);
 
         Ok(Id { bytes: tmp })
     }
@@ -45,19 +43,19 @@ impl Id {
         let mut rng = thread_rng();
         let r: u8 = rng.gen();
 
-        let magic_prefix = IdPrefixMagic::from_ip(&ip, r);
+        let magic_prefix = IdPrefixMagic::from_ip(ip, r);
 
         let mut bytes = [0; ID_SIZE];
 
         bytes[0] = magic_prefix.prefix[0];
         bytes[1] = magic_prefix.prefix[1];
         bytes[2] = (magic_prefix.prefix[2] & 0xf8) | (rng.gen::<u8>() & 0x7);
-        for i in 3..ID_SIZE - 1 {
-            bytes[i] = rng.gen();
+        for item in bytes.iter_mut().take(ID_SIZE - 1).skip(3) {
+            *item = rng.gen();
         }
         bytes[ID_SIZE - 1] = r;
 
-        return Id { bytes: bytes };
+        Id { bytes }
     }
 
     /// Generates a completely random Id. The returned Id is *not* guaranteed to be
@@ -66,7 +64,7 @@ impl Id {
         let mut bytes: [u8; ID_SIZE] = [0; ID_SIZE];
         rng.fill_bytes(&mut bytes);
 
-        return Id { bytes: bytes };
+        Id { bytes }
     }
 
     /// Copies the byes that make up the Id and returns them in a Vec
@@ -84,9 +82,9 @@ impl Id {
             return true;
         }
         let expected = IdPrefixMagic::from_ip(ip, self.bytes[ID_SIZE - 1]);
-        let actual = IdPrefixMagic::from_id(&self);
+        let actual = IdPrefixMagic::from_id(self);
 
-        return expected == actual;
+        expected == actual
     }
 
     /// Returns the number of bits of prefix that the two ids have in common.
@@ -94,7 +92,7 @@ impl Id {
     /// Consider two Ids with binary values `10100000` and `10100100`. This function
     /// would return `5` because the Ids share the common 5-bit prefix `10100`.
     pub fn matching_prefix_bits(&self, other: &Self) -> usize {
-        let xored = self.xor(&other);
+        let xored = self.xor(other);
         let mut to_ret: usize = 0;
 
         for i in 0..ID_SIZE {
@@ -102,14 +100,14 @@ impl Id {
                 .leading_zeros()
                 .try_into()
                 .expect("this should never fail");
-            to_ret = to_ret + leading_zeros;
+            to_ret += leading_zeros;
 
             if leading_zeros < 8 {
                 break;
             }
         }
 
-        return to_ret;
+        to_ret
     }
 
     /// Creates an Id from a hex string.
@@ -128,8 +126,8 @@ impl Id {
     /// Example: `let distance_between_nodes = id.xor(other_id);`
     pub fn xor(&self, other: &Id) -> Id {
         let mut bytes: [u8; ID_SIZE] = [0; ID_SIZE];
-        for i in 0..ID_SIZE {
-            bytes[i] = self.bytes[i] ^ other.bytes[i];
+        for (i, item ) in  bytes.iter_mut().enumerate().take(ID_SIZE) {
+            *item = self.bytes[i] ^ other.bytes[i];
         }
 
         Id::from_bytes(&bytes).expect("Wrong number of bytes for id")
@@ -140,7 +138,7 @@ impl Id {
     /// `identical_bytes` must be in the range (0, [ID_SIZE](crate::common::ID_SIZE)) otherwise Err
     /// is returned.
     pub fn make_mutant(&self, identical_bytes: usize) -> Result<Id, RustyDHTError> {
-        if identical_bytes <= 0 || identical_bytes >= ID_SIZE {
+        if identical_bytes == 0 || identical_bytes >= ID_SIZE {
             return Err(RustyDHTError::GeneralError(anyhow!(
                 "identical_bytes must be in range (0, ID_SIZE)"
             )));
@@ -170,20 +168,14 @@ impl std::fmt::Debug for Id {
     }
 }
 
-impl std::hash::Hash for Id {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.bytes.hash(state);
-    }
-}
-
 impl PartialOrd for Id {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         for i in 0..self.bytes.len() {
-            if self.bytes[i] < other.bytes[i] {
-                return Some(std::cmp::Ordering::Less);
-            } else if self.bytes[i] > other.bytes[i] {
-                return Some(std::cmp::Ordering::Greater);
-            }
+            match self.bytes[i].cmp(&other.bytes[i]) {
+                 std::cmp::Ordering::Less =>  return Some(std::cmp::Ordering::Less),
+                 std::cmp::Ordering::Greater => return Some(std::cmp::Ordering::Greater),
+                 _ => continue,
+            };
         }
 
         Some(std::cmp::Ordering::Equal)
@@ -201,12 +193,12 @@ impl IdPrefixMagic {
     // This isn't a way to generate a valid IdPrefixMagic from a random id.
     // For that, use Id::from_ip
     fn from_id(id: &Id) -> IdPrefixMagic {
-        return IdPrefixMagic {
+        IdPrefixMagic {
             prefix: id.bytes[..3]
                 .try_into()
                 .expect("Failed to grab first three bytes of id"),
             suffix: id.bytes[ID_SIZE - 1],
-        };
+        }
     }
 
     fn from_ip(ip: &IpAddr, seed_r: u8) -> IdPrefixMagic {
@@ -217,12 +209,12 @@ impl IdPrefixMagic {
                 let ip_int: u32 = u32::from_be_bytes(ipv4.octets());
                 let nonsense: u32 = (ip_int & magic) | (r32 << 29);
                 let crc: u32 = crc32::checksum_castagnoli(&nonsense.to_be_bytes());
-                return IdPrefixMagic {
+                IdPrefixMagic {
                     prefix: crc.to_be_bytes()[..3]
                         .try_into()
                         .expect("Failed to convert bytes 0-2 of the crc into a 3-byte array"),
                     suffix: seed_r,
-                };
+                }
             }
             IpAddr::V6(ipv6) => {
                 let r64: u64 = seed_r.into();
@@ -234,21 +226,21 @@ impl IdPrefixMagic {
                 );
                 let nonsense: u64 = ip_int & magic | (r64 << 61);
                 let crc: u32 = crc32::checksum_castagnoli(&nonsense.to_be_bytes());
-                return IdPrefixMagic {
+                IdPrefixMagic {
                     prefix: crc.to_be_bytes()[..2].try_into().expect("Failed to poop"),
                     suffix: seed_r,
-                };
+                }
             }
-        };
+        }
     }
 }
 
 impl PartialEq for IdPrefixMagic {
     fn eq(&self, other: &Self) -> bool {
-        return self.prefix[0] == other.prefix[0]
+       self.prefix[0] == other.prefix[0]
             && self.prefix[1] == other.prefix[1]
             && self.prefix[2] & 0xf8 == other.prefix[2] & 0xf8
-            && self.suffix == other.suffix;
+            && self.suffix == other.suffix
     }
 }
 
@@ -311,22 +303,22 @@ mod tests {
         let h1 = Id::from_hex("0000000000000000000000000000000000000001").unwrap();
         let h2 = Id::from_hex("0000000000000000000000000000000000000000").unwrap();
         let h3 = h1.xor(&h2);
-        assert!(h3 == h1);
+        assert_eq!(h3, h1);
 
         let h1 = Id::from_hex("0000000000000000000000000000000000000001").unwrap();
         let h2 = Id::from_hex("0000000000000000000000000000000000000001").unwrap();
         let h3 = h1.xor(&h2);
-        assert!(h3 == Id::from_hex("0000000000000000000000000000000000000000").unwrap());
+        assert_eq!(h3, Id::from_hex("0000000000000000000000000000000000000000").unwrap());
 
         let h1 = Id::from_hex("1010101010101010101010101010101010101010").unwrap();
         let h2 = Id::from_hex("0101010101010101010101010101010101010101").unwrap();
         let h3 = h1.xor(&h2);
-        assert!(h3 == Id::from_hex("1111111111111111111111111111111111111111").unwrap());
+        assert_eq!(h3, Id::from_hex("1111111111111111111111111111111111111111").unwrap());
 
         let h1 = Id::from_hex("fefefefefefefefefefefefefefefefefefefefe").unwrap();
         let h2 = Id::from_hex("0505050505050505050505050505050505050505").unwrap();
         let h3 = h1.xor(&h2);
-        assert!(h3 == Id::from_hex("fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb").unwrap());
+        assert_eq!(h3, Id::from_hex("fbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb").unwrap());
     }
 
     #[test]
@@ -335,31 +327,31 @@ mod tests {
         let h2 = Id::from_hex("0000000000000000000000000000000000000000").unwrap();
         assert!(h1 > h2);
         assert!(h2 < h1);
-        assert!(h1 != h2);
+        assert_ne!(h1, h2);
 
         let h1 = Id::from_hex("00000000000000000000f0000000000000000000").unwrap();
         let h2 = Id::from_hex("000000000000000000000fffffffffffffffffff").unwrap();
         assert!(h1 > h2);
         assert!(h2 < h1);
-        assert!(h1 != h2);
+        assert_ne!(h1, h2);
 
         let h1 = Id::from_hex("1000000000000000000000000000000000000000").unwrap();
         let h2 = Id::from_hex("0fffffffffffffffffffffffffffffffffffffff").unwrap();
         assert!(h1 > h2);
         assert!(h2 < h1);
-        assert!(h1 != h2);
+        assert_ne!(h1, h2);
 
         let h1 = Id::from_hex("1010101010101010101010101010101010101010").unwrap();
         let h2 = Id::from_hex("1010101010101010101010101010101010101010").unwrap();
-        assert!(!(h1 > h2));
-        assert!(!(h2 > h1));
-        assert!(h1 == h2);
+        assert!(h1 <= h2);
+        assert!(h2 <= h1);
+        assert_eq!(h1, h2);
 
         let h1 = Id::from_hex("0000000000000000000000000000000000000010").unwrap();
         let h2 = Id::from_hex("0000000000000000000000000000000000000001").unwrap();
         assert!(h1 > h2);
         assert!(h2 < h1);
-        assert!(h1 != h2);
+        assert_ne!(h1, h2);
     }
 
     #[test]

--- a/src/common/ipv4_addr_src.rs
+++ b/src/common/ipv4_addr_src.rs
@@ -104,9 +104,7 @@ impl IPV4AddrSource for IPV4Consensus {
         }
 
         if do_sort {
-            self.votes.sort_by(|a, b| {
-                b.votes.cmp(&a.votes)
-            });
+            self.votes.sort_by(|a, b| b.votes.cmp(&a.votes));
         } else {
             self.votes.push(IPV4Vote {
                 ip: proposed_addr,
@@ -121,9 +119,7 @@ impl IPV4AddrSource for IPV4Consensus {
         }
 
         // Optimize this if we care (hint: we probably don't)
-        self.votes.retain(|a| {
-            a.votes > 0
-        })
+        self.votes.retain(|a| a.votes > 0)
     }
 }
 

--- a/src/common/ipv4_addr_src.rs
+++ b/src/common/ipv4_addr_src.rs
@@ -69,8 +69,8 @@ pub struct IPV4Consensus {
 impl IPV4Consensus {
     pub fn new(min_votes: usize, max_votes: usize) -> IPV4Consensus {
         IPV4Consensus {
-            min_votes: min_votes,
-            max_votes: max_votes,
+            min_votes,
+            max_votes,
             votes: Vec::new(),
         }
     }
@@ -105,7 +105,7 @@ impl IPV4AddrSource for IPV4Consensus {
 
         if do_sort {
             self.votes.sort_by(|a, b| {
-                return b.votes.cmp(&a.votes);
+                b.votes.cmp(&a.votes)
             });
         } else {
             self.votes.push(IPV4Vote {
@@ -122,7 +122,7 @@ impl IPV4AddrSource for IPV4Consensus {
 
         // Optimize this if we care (hint: we probably don't)
         self.votes.retain(|a| {
-            return a.votes > 0;
+            a.votes > 0
         })
     }
 }

--- a/src/common/node.rs
+++ b/src/common/node.rs
@@ -12,9 +12,6 @@ pub struct Node {
 impl Node {
     /// Creates a new Node from an id and socket address.
     pub fn new(id: Id, address: SocketAddr) -> Node {
-        Node {
-            id,
-            address,
-        }
+        Node { id, address }
     }
 }

--- a/src/common/node.rs
+++ b/src/common/node.rs
@@ -13,8 +13,8 @@ impl Node {
     /// Creates a new Node from an id and socket address.
     pub fn new(id: Id, address: SocketAddr) -> Node {
         Node {
-            id: id,
-            address: address,
+            id,
+            address,
         }
     }
 }

--- a/src/common/transaction_id.rs
+++ b/src/common/transaction_id.rs
@@ -7,6 +7,6 @@ pub struct TransactionId {
 
 impl From<Vec<u8>> for TransactionId {
     fn from(tid: Vec<u8>) -> Self {
-        return TransactionId { bytes: tid };
+        TransactionId { bytes: tid }
     }
 }

--- a/src/dht/builder.rs
+++ b/src/dht/builder.rs
@@ -7,7 +7,7 @@ use crate::storage::node_bucket_storage::{NodeBucketStorage, NodeStorage};
 use std::net::{Ipv4Addr, SocketAddrV4};
 
 /// Helps to configure and create new [DHT](crate::dht::DHT) instances.
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct DHTBuilder {
     initial_id: Option<Id>,
     listen_addr: Option<SocketAddrV4>,
@@ -19,13 +19,7 @@ pub struct DHTBuilder {
 impl DHTBuilder {
     /// Creates a new DHTBuilder
     pub fn new() -> DHTBuilder {
-        DHTBuilder {
-            initial_id: None,
-            listen_addr: None,
-            ip_source: None,
-            route_table: None,
-            settings: None,
-        }
+        Self::default()
     }
 
     /// Set the initial Id for your DHT node.
@@ -94,7 +88,7 @@ impl DHTBuilder {
                 .unwrap_or_else(|| Box::new(IPV4Consensus::new(2, 10))),
             self.route_table
                 .unwrap_or_else(|| Box::new(NodeBucketStorage::new(Id::ZERO, 8))),
-            self.settings.unwrap_or_else(|| DHTSettings::default()),
+            self.settings.unwrap_or_else(DHTSettings::default),
         )
     }
 }

--- a/src/dht/dht.rs
+++ b/src/dht/dht.rs
@@ -838,6 +838,9 @@ impl DHT {
                                 .add_or_update(Node::new(their_id, target), true);
                         }
 
+                        // Special handling for find_node responses
+                        // Add the nodes we got back as "seen" (even though we haven't necessarily seen them directly yet).
+                        // They will be pinged later in an attempt to verify them.
                         if let packets::ResponseSpecific::FindNodeResponse(args) = response_variant {
                             let mut state = state.lock().unwrap();
                             for node in &args.nodes {

--- a/src/dht/dht.rs
+++ b/src/dht/dht.rs
@@ -69,7 +69,7 @@ impl DHT {
             .iter()
             .copied()
             .map(|hash| (hash, state.peer_storage.get_peers_info(&hash, newer_than)))
-            .filter(|tup| tup.1.len() > 0)
+            .filter(|tup| !tup.1.is_empty())
             .collect()
     }
 
@@ -145,22 +145,22 @@ impl DHT {
         let token_secret = make_token_secret(settings.token_secret_size);
 
         let dht = DHT {
-            socket: socket,
+            socket,
             state: Arc::new(Mutex::new(DHTState {
-                ip4_source: ip4_source,
-                our_id: our_id,
-                buckets: buckets,
+                ip4_source,
+                our_id,
+                buckets,
                 peer_storage: PeerStorage::new(
                     settings.max_torrents,
                     settings.max_peers_per_torrent,
                 ),
                 token_secret: token_secret.clone(),
                 old_token_secret: token_secret,
-                settings: settings,
+                settings,
                 subscribers: vec![],
             })),
 
-            shutdown: shutdown,
+            shutdown,
         };
 
         Ok(dht)
@@ -185,7 +185,7 @@ impl DHT {
                     "run_event_loop should shutdown"
                 )));
                 self.shutdown.clone().watch().await;
-                return to_ret;
+                to_ret
             }
         ) {
             Ok(_) => Ok(()),
@@ -312,7 +312,7 @@ impl DHT {
                     }
 
                     _ => {
-                        return Err(err.into());
+                        return Err(err);
                     }
                 },
             }
@@ -393,7 +393,7 @@ impl DHT {
                             };
                             let token = calculate_token(&addr, state.token_secret.clone());
 
-                            let reply = match peers.len() {
+                             match peers.len() {
                                 0 => {
                                     let nearest = state.buckets.get_nearest_nodes(
                                         &arguments.info_hash,
@@ -401,7 +401,7 @@ impl DHT {
                                     );
 
                                     MessageBuilder::new_get_peers_response()
-                                        .sender_id(state.our_id.clone())
+                                        .sender_id(state.our_id)
                                         .transaction_id(msg.transaction_id)
                                         .requester_ip(addr)
                                         .token(token.to_vec())
@@ -410,14 +410,13 @@ impl DHT {
                                 }
 
                                 _ => MessageBuilder::new_get_peers_response()
-                                    .sender_id(state.our_id.clone())
+                                    .sender_id(state.our_id)
                                     .transaction_id(msg.transaction_id)
                                     .requester_ip(addr)
                                     .token(token.to_vec())
                                     .peers(peers)
                                     .build()?,
-                            };
-                            reply
+                            }
                         };
                         self.socket
                             .send_to(reply, addr, Some(arguments.requester_id))
@@ -433,7 +432,7 @@ impl DHT {
                                 Some(&arguments.requester_id),
                             );
                             MessageBuilder::new_find_node_response()
-                                .sender_id(state.our_id.clone())
+                                .sender_id(state.our_id)
                                 .transaction_id(msg.transaction_id)
                                 .requester_ip(addr)
                                 .nodes(nearest)
@@ -457,10 +456,10 @@ impl DHT {
 
                             if is_token_valid {
                                 let sockaddr = match arguments.implied_port {
-                                    Some(implied_port) if implied_port == true => addr,
+                                    Some(implied_port) if implied_port => addr,
 
                                     _ => {
-                                        let mut tmp = addr.clone();
+                                        let mut tmp = addr;
                                         tmp.set_port(arguments.port);
                                         tmp
                                     }
@@ -549,7 +548,7 @@ impl DHT {
             }
         }
 
-        return Ok(());
+        Ok(())
     }
 
     async fn send_packet_to_subscribers(&self, msg: packets::Message, _addr: SocketAddr) {
@@ -674,7 +673,7 @@ impl DHT {
 
             // If we don't know anybody, force a router ping.
             // This is helpful if we've been asleep for a while and lost all peers
-            if count_verified <= 0 {
+            if count_verified == 0 {
                 self.ping_routers(shutdown.clone()).await?;
             }
 
@@ -839,19 +838,13 @@ impl DHT {
                                 .add_or_update(Node::new(their_id, target), true);
                         }
 
-                        match response_variant {
-                            // Special handling for find_node responses
-                            // Add the nodes we got back as "seen" (even though we haven't necessarily seen them directly yet).
-                            // They will be pinged later in an attempt to verify them.
-                            packets::ResponseSpecific::FindNodeResponse(args) => {
-                                let mut state = state.lock().unwrap();
-                                for node in &args.nodes {
-                                    if node.id.is_valid_for_ip(&node.address.ip()) {
-                                        state.buckets.add_or_update(node.clone(), false);
-                                    }
+                        if let packets::ResponseSpecific::FindNodeResponse(args) = response_variant {
+                            let mut state = state.lock().unwrap();
+                            for node in &args.nodes {
+                                if node.id.is_valid_for_ip(&node.address.ip()) {
+                                    state.buckets.add_or_update(node.clone(), false);
                                 }
                             }
-                            _ => {}
                         }
 
                         Ok(reply)
@@ -974,12 +967,10 @@ impl DHT {
     /// Adds a 'vote' for whatever IP address the sender says we have.
     fn ip4_vote_helper(state: &mut DHTState, addr: &SocketAddr, msg: &packets::Message) {
         if let IpAddr::V4(their_ip) = addr.ip() {
-            if let Some(they_claim_our_sockaddr) = &msg.requester_ip {
-                if let SocketAddr::V4(they_claim_our_sockaddr) = they_claim_our_sockaddr {
+            if let Some(SocketAddr::V4(they_claim_our_sockaddr)) = &msg.requester_ip {
                     state
                         .ip4_source
-                        .add_vote(their_ip, they_claim_our_sockaddr.ip().clone());
-                }
+                        .add_vote(their_ip, *they_claim_our_sockaddr.ip());
             }
         }
     }
@@ -1000,7 +991,7 @@ fn calculate_token<T: AsRef<[u8]>>(remote: &SocketAddr, secret: T) -> [u8; 4] {
     digest.write(secret);
     let checksum: u32 = digest.sum32();
 
-    return checksum.to_be_bytes();
+    checksum.to_be_bytes()
 }
 
 fn make_token_secret(size: usize) -> Vec<u8> {

--- a/src/dht/dht.rs
+++ b/src/dht/dht.rs
@@ -393,7 +393,7 @@ impl DHT {
                             };
                             let token = calculate_token(&addr, state.token_secret.clone());
 
-                             match peers.len() {
+                            match peers.len() {
                                 0 => {
                                     let nearest = state.buckets.get_nearest_nodes(
                                         &arguments.info_hash,
@@ -968,9 +968,9 @@ impl DHT {
     fn ip4_vote_helper(state: &mut DHTState, addr: &SocketAddr, msg: &packets::Message) {
         if let IpAddr::V4(their_ip) = addr.ip() {
             if let Some(SocketAddr::V4(they_claim_our_sockaddr)) = &msg.requester_ip {
-                    state
-                        .ip4_source
-                        .add_vote(their_ip, *they_claim_our_sockaddr.ip());
+                state
+                    .ip4_source
+                    .add_vote(their_ip, *they_claim_our_sockaddr.ip());
             }
         }
     }

--- a/src/dht/dht_settings.rs
+++ b/src/dht/dht_settings.rs
@@ -71,9 +71,9 @@ pub struct DHTSettings {
     pub routers: Vec<String>,
 }
 
-impl DHTSettings {
-    /// Returns DHTSettings with a default set of options.
-    pub fn default() -> DHTSettings {
+/// Returns DHTSettings with a default set of options.
+impl Default for DHTSettings {
+    fn default() -> Self {
         DHTSettings {
             token_secret_size: 10,
             max_peers_response: 128,
@@ -98,12 +98,6 @@ impl DHTSettings {
                 "dht.transmissionbt.com:6881".to_string(),
             ],
         }
-    }
-}
-
-impl Default for DHTSettings {
-    fn default() -> Self {
-        Self::default()
     }
 }
 

--- a/src/dht/dht_settings.rs
+++ b/src/dht/dht_settings.rs
@@ -101,7 +101,13 @@ impl DHTSettings {
     }
 }
 
-#[derive(Clone)]
+impl Default for DHTSettings {
+    fn default() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Clone, Default)]
 /// Builder for DHTSettings
 pub struct DHTSettingsBuilder {
     settings: DHTSettings,
@@ -118,9 +124,7 @@ macro_rules! make_builder_method {
 
 impl DHTSettingsBuilder {
     pub fn new() -> DHTSettingsBuilder {
-        DHTSettingsBuilder {
-            settings: DHTSettings::default(),
-        }
+        Self::default()
     }
 
     make_builder_method!(token_secret_size, usize);

--- a/src/dht/operations.rs
+++ b/src/dht/operations.rs
@@ -180,7 +180,7 @@ pub async fn find_node(
     })
     .await;
 
-    if let Err(timeout) = find_node_result  {
+    if let Err(timeout) = find_node_result {
         debug!(target: "rustydht_lib::operations::find_node", "Timed out after {:?}", timeout);
     }
 
@@ -372,10 +372,7 @@ pub struct GetPeersResponder {
 
 impl GetPeersResponder {
     pub fn new(node: Node, token: Vec<u8>) -> GetPeersResponder {
-        GetPeersResponder {
-            node,
-            token,
-        }
+        GetPeersResponder { node, token }
     }
 
     pub fn node(self) -> Node {

--- a/src/dht/operations.rs
+++ b/src/dht/operations.rs
@@ -40,14 +40,8 @@ pub async fn announce_peer(
         .sender_id(dht.get_id())
         .read_only(dht.get_settings().read_only)
         .target(info_hash)
-        .port(match port {
-            Some(p) => p,
-            None => 0,
-        })
-        .implied_port(match port {
-            Some(_) => false,
-            None => true,
-        });
+        .port(port.unwrap_or(0))
+        .implied_port(port.is_none());
 
     // Prepare to send packets to the nearest 8
     let mut todos = futures::stream::FuturesUnordered::new();
@@ -106,7 +100,7 @@ pub async fn find_node(
     let mut buckets = Buckets::new(target, 8);
     let dht_settings = dht.get_settings();
 
-    if let Err(_) = tokio::time::timeout(timeout, async {
+    let find_node_result = tokio::time::timeout(timeout, async {
         let mut best_ids = Vec::new();
         loop {
             // Seed our buckets with the main buckets from the DHT
@@ -118,12 +112,12 @@ pub async fn find_node(
 
             // Grab a few nodes closest to our target
             let nearest = buckets.get_nearest_nodes(&target, None);
-            if nearest.len() <= 0 {
+            if nearest.is_empty() {
                 // If there are no nodes in the buckets yet, DHT may still be bootstrapping. Give it a moment and try again
                 tokio::time::sleep(Duration::from_secs(1)).await;
                 continue;
             }
-            let best_ids_current: Vec<Id> = nearest.iter().map(|nw| nw.node.id.clone()).collect();
+            let best_ids_current: Vec<Id> = nearest.iter().map(|nw| nw.node.id).collect();
             if best_ids == best_ids_current {
                 break;
             }
@@ -184,8 +178,9 @@ pub async fn find_node(
             }
         }
     })
-    .await
-    {
+    .await;
+
+    if let Err(timeout) = find_node_result  {
         debug!(target: "rustydht_lib::operations::find_node", "Timed out after {:?}", timeout);
     }
 
@@ -213,7 +208,7 @@ pub async fn get_peers(
     // Hack to aid in bootstrapping
     find_node(dht, info_hash, Duration::from_secs(5)).await?;
 
-    if let Err(_) = tokio::time::timeout(timeout,
+    let get_peers_result = tokio::time::timeout(timeout,
     async {
         let mut best_ids = Vec::new();
         loop {
@@ -231,7 +226,7 @@ pub async fn get_peers(
                 tokio::time::sleep(Duration::from_secs(1)).await;
                 continue;
             }
-            let best_ids_current: Vec<Id> = nearest.iter().map(|nw| nw.node.id.clone()).collect();
+            let best_ids_current: Vec<Id> = nearest.iter().map(|nw| nw.node.id).collect();
             if best_ids == best_ids_current {
                 break;
             }
@@ -311,7 +306,9 @@ pub async fn get_peers(
                 tokio::time::sleep(needed_sleep_interval).await;
             }
         }
-    }).await {
+    }).await;
+
+    if let Err(timeout) = get_peers_result {
         debug!(target: "rustydht_lib::operations::get_peers", "Timed out after {:?}, returning current results", timeout);
     }
 
@@ -341,9 +338,9 @@ impl GetPeersResult {
             a_dist.partial_cmp(&b_dist).unwrap()
         });
         GetPeersResult {
-            info_hash: info_hash,
-            peers: peers,
-            responders: responders,
+            info_hash,
+            peers,
+            responders,
         }
     }
 
@@ -376,8 +373,8 @@ pub struct GetPeersResponder {
 impl GetPeersResponder {
     pub fn new(node: Node, token: Vec<u8>) -> GetPeersResponder {
         GetPeersResponder {
-            node: node,
-            token: token,
+            node,
+            token,
         }
     }
 

--- a/src/dht/socket.rs
+++ b/src/dht/socket.rs
@@ -187,13 +187,13 @@ impl DHTSocket {
 
                 match request_info {
                     Some(request_info) => {
+                        // It's fine if there's no channel - just means that the sender didn't care about getting a response
                         if let Some(response_channel) = request_info.response_channel {
                             if let Err(e) = response_channel.send(message.clone()).await {
                                 let message = e.0;
                                 warn!(target: "rustydht_lib::DHTSocket", "Got response, but sending code abandoned the channel receiver. So sad. Response: {:?}. Sender: {:?}", message, sender);
                             }
                         }
-                        // It's fine if there's no channel - just means that the sender didn't care about getting a response
 
                         // Since the response is to a valid request, send it to the general recv channel
                         recv_from_tx

--- a/src/packets/internal.rs
+++ b/src/packets/internal.rs
@@ -101,7 +101,7 @@ pub enum DHTResponseSpecific {
         arguments: DHTFindNodeResponseArguments,
     },
 
-    PingResponse {
+    Ping {
         #[serde(rename = "r")]
         arguments: DHTPingResponseArguments,
     },
@@ -251,7 +251,7 @@ mod tests {
             transaction_id: vec![0xb5, 0x1b],
             ip: Some(hex::decode("48a8858f2014").unwrap()),
             version: Some(hex::decode("5554b3ba").unwrap()),
-            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::PingResponse {
+            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::Ping {
                 arguments: DHTPingResponseArguments {
                     id: hex::decode("70f22fcfdc27e4ff28f0c00a6a3de0d6c4361ccd").unwrap(),
                 },
@@ -406,7 +406,7 @@ mod tests {
             transaction_id: hex::decode("1d4c0100").unwrap(),
             ip: Some(hex::decode("725c2f242e87").unwrap()),
             version: None,
-            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::PingResponse {
+            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::Ping {
                 arguments: DHTPingResponseArguments {
                     id: hex::decode("70f923e90771701587b6d36fbb78b3a8047b092e").unwrap(),
                 },

--- a/src/packets/internal.rs
+++ b/src/packets/internal.rs
@@ -32,8 +32,7 @@ impl DHTMessage {
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, RustyDHTError> {
-        serde_bencode::to_bytes(self)
-            .map_err(RustyDHTError::PacketSerializationError)
+        serde_bencode::to_bytes(self).map_err(RustyDHTError::PacketSerializationError)
     }
 }
 
@@ -427,14 +426,12 @@ mod tests {
             transaction_id: vec![0x61, 0x61],
             ip: None,
             version: None,
-            variant: DHTMessageVariant::DHTRequest(
-                DHTRequestSpecific::SampleInfoHashes {
-                    arguments: DHTSampleInfoHashesRequestArguments {
-                        id: hex::decode("0000000000000000000000000000000000000000").unwrap(),
-                        target: hex::decode("bad6487806506bd534e78a8e375e3f59f7bb5ee0").unwrap(),
-                    },
+            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::SampleInfoHashes {
+                arguments: DHTSampleInfoHashesRequestArguments {
+                    id: hex::decode("0000000000000000000000000000000000000000").unwrap(),
+                    target: hex::decode("bad6487806506bd534e78a8e375e3f59f7bb5ee0").unwrap(),
                 },
-            ),
+            }),
             read_only: None,
         };
 

--- a/src/packets/internal.rs
+++ b/src/packets/internal.rs
@@ -33,7 +33,7 @@ impl DHTMessage {
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, RustyDHTError> {
         serde_bencode::to_bytes(self)
-            .map_err(|err| RustyDHTError::PacketSerializationError(err.into()))
+            .map_err(RustyDHTError::PacketSerializationError)
     }
 }
 
@@ -54,31 +54,31 @@ pub enum DHTMessageVariant {
 #[serde(tag = "q")]
 pub enum DHTRequestSpecific {
     #[serde(rename = "ping")]
-    DHTPingRequest {
+    Ping {
         #[serde(rename = "a")]
         arguments: DHTPingArguments,
     },
 
     #[serde(rename = "find_node")]
-    DHTFindNodeRequest {
+    FindNode {
         #[serde(rename = "a")]
         arguments: DHTFindNodeArguments,
     },
 
     #[serde(rename = "get_peers")]
-    DHTGetPeersRequest {
+    GetPeers {
         #[serde(rename = "a")]
         arguments: DHTGetPeersArguments,
     },
 
     #[serde(rename = "announce_peer")]
-    DHTAnnouncePeerRequest {
+    AnnouncePeer {
         #[serde(rename = "a")]
         arguments: DHTAnnouncePeerRequestArguments,
     },
 
     #[serde(rename = "sample_infohashes")]
-    DHTSampleInfoHashesRequest {
+    SampleInfoHashes {
         #[serde(rename = "a")]
         arguments: DHTSampleInfoHashesRequestArguments,
     },
@@ -87,22 +87,22 @@ pub enum DHTRequestSpecific {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)] // This means order matters! Order these from most to least detailed
 pub enum DHTResponseSpecific {
-    DHTGetPeersResponse {
+    GetPeers {
         #[serde(rename = "r")]
         arguments: DHTGetPeersResponseArguments,
     },
 
-    DHTSampleInfoHashesResponse {
+    SampleInfoHashes {
         #[serde(rename = "r")]
         arguments: DHTSampleInfoHashesResponseArguments,
     },
 
-    DHTFindNodeResponse {
+    FindNode {
         #[serde(rename = "r")]
         arguments: DHTFindNodeResponseArguments,
     },
 
-    DHTPingResponse {
+    PingResponse {
         #[serde(rename = "r")]
         arguments: DHTPingResponseArguments,
     },
@@ -232,7 +232,7 @@ mod tests {
             transaction_id: vec![0xb5, 0x1b],
             ip: None,
             version: None,
-            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::DHTPingRequest {
+            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::Ping {
                 arguments: DHTPingArguments {
                     id: hex::decode("70f923e90771701587b6d36fbb78b3a8047b092e").unwrap(),
                 },
@@ -252,7 +252,7 @@ mod tests {
             transaction_id: vec![0xb5, 0x1b],
             ip: Some(hex::decode("48a8858f2014").unwrap()),
             version: Some(hex::decode("5554b3ba").unwrap()),
-            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::DHTPingResponse {
+            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::PingResponse {
                 arguments: DHTPingResponseArguments {
                     id: hex::decode("70f22fcfdc27e4ff28f0c00a6a3de0d6c4361ccd").unwrap(),
                 },
@@ -272,7 +272,7 @@ mod tests {
             transaction_id: vec![0xac, 0xc4, 0xe5, 0x2e],
             ip: None,
             version: None,
-            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::DHTGetPeersRequest {
+            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::GetPeers {
                 arguments: DHTGetPeersArguments {
                     id: hex::decode("287cbd6f580fcf5920aafe67478a0c882ab2ee8e").unwrap(),
                     info_hash: hex::decode("70f986a9fb5a9e8e0bafc62165b7178360332109").unwrap(),
@@ -293,7 +293,7 @@ mod tests {
             transaction_id: vec!(0xa0, 0xbc),
             ip: Some(hex::decode("334f9e687d01").unwrap()),
             version: None,
-            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::DHTGetPeersResponse {
+            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::GetPeers {
                 arguments: DHTGetPeersResponseArguments {
                     id: hex::decode("70f923e90771701587b6d36fbb78b3a8047b092e").unwrap(),
                     nodes: Some(hex::decode("70e9325426374aff7f909e8f14faeda58d4f9a68b925f813d37f70eeac0aaef80a095f190dfddd17787eec980182578a6199db0d70ee20a15db5e9c7eee898a14d461fb262e9907c47c213fd1ae970ed932dd5335ab19eaa4f1820814662bb1eea025169e8c1bf6670ed65b14cfcbb854b838465950cc00cd97aeb625d68eb4251f670ec53526e4fe3e0bea78e796ece96b024fd749b05c44818cf0870e0c53d2a3899fd53b2e1ffc8afa95374e0d6cdb0099d9c232770e74ed6ae529049f1f1bbe9ebb3a6db3c870ce152150dd9d8be").unwrap()),
@@ -316,7 +316,7 @@ mod tests {
             transaction_id: vec![0x41, 0x16, 0x00, 0x00],
             ip: None,
             version: Some(vec![0x55, 0x54, 0xb3, 0xba]),
-            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::DHTFindNodeRequest {
+            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::FindNode {
                 arguments: DHTFindNodeArguments {
                     id: hex::decode("93b7d318a5034a01231c86f68f385468e67038c6").unwrap(),
                     target: hex::decode("4800711700005e9e00001b190000391d00005a95").unwrap(),
@@ -337,7 +337,7 @@ mod tests {
                 transaction_id: vec!(0x41, 0x16, 0x00, 0x00),
                 ip: Some(hex::decode("2969788ee79d").unwrap()),
                 version: None,
-                variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::DHTFindNodeResponse {
+                variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::FindNode {
                     arguments: DHTFindNodeResponseArguments {
                         id: hex::decode("70f923e90771701587b6d36fbb78b3a8047b092e").unwrap(),
                         nodes: hex::decode("4bcf558e1e7f7543f63f6cd57ca9c50d446e898d5f5499481ae14bf18f4fa61e6fc2a944b024511bfc0f67997eff8e86c3565f854f65edbc03f23184dedf8d8619b0916bbcaca617d5855fc71ae14fb2b2feff1694d9a3ccbda1c68dbe4efb62f08f5f58f6cb1ae142024361c0ecf637b4125af472a8214fe49c9603a93f15571ae142db840f263413b8a8603e1e87fea7cc0bf1bd0c3216850a1ae15b506431ba2475bbe30a243217c091adafe45f563b157ed71f525bc83812fadb89e6d47df829a327b951c9b726a9a93dda2d1ae1").unwrap(),
@@ -358,7 +358,7 @@ mod tests {
             transaction_id: hex::decode("1d4c0100").unwrap(),
             ip: None,
             version: None,
-            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::DHTAnnouncePeerRequest {
+            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::AnnouncePeer {
                 arguments: DHTAnnouncePeerRequestArguments {
                     id: hex::decode("a4df50d016f245e487bd6c2ce324922b5e2a7e56").unwrap(),
                     info_hash: hex::decode("70f936a4d868a160b3d28e258a949da5269f95dd").unwrap(),
@@ -382,7 +382,7 @@ mod tests {
             transaction_id: hex::decode("fda0a901").unwrap(),
             ip: None,
             version: None,
-            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::DHTAnnouncePeerRequest {
+            variant: DHTMessageVariant::DHTRequest(DHTRequestSpecific::AnnouncePeer {
                 arguments: DHTAnnouncePeerRequestArguments {
                     id: hex::decode("4dc3d74ff5133ab5fb45b8e919e5083e516e9e73").unwrap(),
                     info_hash: hex::decode("0dfb5308ef7e64a929d1a836fa40a12eddbfaf12").unwrap(),
@@ -407,7 +407,7 @@ mod tests {
             transaction_id: hex::decode("1d4c0100").unwrap(),
             ip: Some(hex::decode("725c2f242e87").unwrap()),
             version: None,
-            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::DHTPingResponse {
+            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::PingResponse {
                 arguments: DHTPingResponseArguments {
                     id: hex::decode("70f923e90771701587b6d36fbb78b3a8047b092e").unwrap(),
                 },
@@ -428,7 +428,7 @@ mod tests {
             ip: None,
             version: None,
             variant: DHTMessageVariant::DHTRequest(
-                DHTRequestSpecific::DHTSampleInfoHashesRequest {
+                DHTRequestSpecific::SampleInfoHashes {
                     arguments: DHTSampleInfoHashesRequestArguments {
                         id: hex::decode("0000000000000000000000000000000000000000").unwrap(),
                         target: hex::decode("bad6487806506bd534e78a8e375e3f59f7bb5ee0").unwrap(),
@@ -450,7 +450,7 @@ mod tests {
             transaction_id: vec![0x61, 0x61],
             ip: Some(hex::decode("ae886914199c").unwrap()),
             version: None,
-            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::DHTSampleInfoHashesResponse {
+            variant: DHTMessageVariant::DHTResponse(DHTResponseSpecific::SampleInfoHashes {
                 arguments: DHTSampleInfoHashesResponseArguments {
                     id: hex::decode("70f923e90771701587b6d36fbb78b3a8047b092e").unwrap(),
                     interval: 10,

--- a/src/packets/public.rs
+++ b/src/packets/public.rs
@@ -203,17 +203,19 @@ impl Message {
         internal::DHTMessage {
             transaction_id: self.transaction_id,
             version: self.version,
-            ip: self.requester_ip.map(|sockaddr| sockaddr_to_bytes(&sockaddr)),
-            read_only: self.read_only.map(|read_only| if read_only { 1 } else { 0 }),
+            ip: self
+                .requester_ip
+                .map(|sockaddr| sockaddr_to_bytes(&sockaddr)),
+            read_only: self
+                .read_only
+                .map(|read_only| if read_only { 1 } else { 0 }),
             variant: match self.message_type {
                 MessageType::Request(req) => internal::DHTMessageVariant::DHTRequest(match req {
-                    RequestSpecific::PingRequest(ping_args) => {
-                        internal::DHTRequestSpecific::Ping {
-                            arguments: internal::DHTPingArguments {
-                                id: ping_args.requester_id.to_vec(),
-                            },
-                        }
-                    }
+                    RequestSpecific::PingRequest(ping_args) => internal::DHTRequestSpecific::Ping {
+                        arguments: internal::DHTPingArguments {
+                            id: ping_args.requester_id.to_vec(),
+                        },
+                    },
 
                     RequestSpecific::FindNodeRequest(find_node_args) => {
                         internal::DHTRequestSpecific::FindNode {
@@ -429,37 +431,37 @@ impl Message {
                             })
                         }
 
-                        internal::DHTResponseSpecific::SampleInfoHashes {
-                            arguments,
-                        } => ResponseSpecific::SampleInfoHashesResponse(
-                            SampleInfoHashesResponseArguments {
-                                responder_id: Id::from_bytes(&arguments.id)?,
-                                interval: Duration::from_secs(arguments.interval as u64),
-                                num: arguments.num,
-                                nodes: bytes_to_nodes4(&arguments.nodes)?,
-                                samples: {
-                                    if arguments.samples.len() % ID_SIZE != 0 {
-                                        return Err(anyhow!(
-                                            "Wrong sample length {} not a multiple of {}",
-                                            arguments.samples.len(),
-                                            ID_SIZE
-                                        )
-                                        .into());
-                                    }
-                                    let num_expected = arguments.samples.len() / ID_SIZE;
-                                    let mut to_ret = Vec::with_capacity(num_expected);
+                        internal::DHTResponseSpecific::SampleInfoHashes { arguments } => {
+                            ResponseSpecific::SampleInfoHashesResponse(
+                                SampleInfoHashesResponseArguments {
+                                    responder_id: Id::from_bytes(&arguments.id)?,
+                                    interval: Duration::from_secs(arguments.interval as u64),
+                                    num: arguments.num,
+                                    nodes: bytes_to_nodes4(&arguments.nodes)?,
+                                    samples: {
+                                        if arguments.samples.len() % ID_SIZE != 0 {
+                                            return Err(anyhow!(
+                                                "Wrong sample length {} not a multiple of {}",
+                                                arguments.samples.len(),
+                                                ID_SIZE
+                                            )
+                                            .into());
+                                        }
+                                        let num_expected = arguments.samples.len() / ID_SIZE;
+                                        let mut to_ret = Vec::with_capacity(num_expected);
 
-                                    for i in 0..num_expected {
-                                        let i = i * ID_SIZE;
-                                        let id =
-                                            Id::from_bytes(&arguments.samples[i..i + ID_SIZE])?;
-                                        to_ret.push(id);
-                                    }
+                                        for i in 0..num_expected {
+                                            let i = i * ID_SIZE;
+                                            let id =
+                                                Id::from_bytes(&arguments.samples[i..i + ID_SIZE])?;
+                                            to_ret.push(id);
+                                        }
 
-                                    to_ret
+                                        to_ret
+                                    },
                                 },
-                            },
-                        ),
+                            )
+                        }
                     })
                 }
 

--- a/src/packets/public.rs
+++ b/src/packets/public.rs
@@ -295,7 +295,7 @@ impl Message {
                     }
 
                     ResponseSpecific::PingResponse(ping_args) => {
-                        internal::DHTResponseSpecific::PingResponse {
+                        internal::DHTResponseSpecific::Ping {
                             arguments: internal::DHTPingResponseArguments {
                                 id: ping_args.responder_id.to_vec(),
                             },
@@ -425,7 +425,7 @@ impl Message {
                             })
                         }
 
-                        internal::DHTResponseSpecific::PingResponse { arguments } => {
+                        internal::DHTResponseSpecific::Ping { arguments } => {
                             ResponseSpecific::PingResponse(PingResponseArguments {
                                 responder_id: Id::from_bytes(&arguments.id)?,
                             })

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -68,7 +68,7 @@ impl ShutdownSender {
         if let Err(e) = self.shutdown_tx.send(true) {
             warn!(target: "rustydht_lib::ShutdownSender","Failed to send shutdown signal - likely all tasks are already stopped. Error: {:?}", e);
         }
-        if let Err(_) = self.shutdown_confirm_rx.recv().await {
+        if self.shutdown_confirm_rx.recv().await.is_err() {
             // This error is expected
         }
         info!(target: "rustydht_lib::ShutdownSender","All tasks have stopped");
@@ -90,11 +90,11 @@ pub fn create_shutdown() -> (ShutdownSender, ShutdownReceiver) {
 
     (
         ShutdownSender {
-            shutdown_tx: shutdown_tx,
-            shutdown_confirm_rx: shutdown_confirm_rx,
+            shutdown_tx,
+            shutdown_confirm_rx,
         },
         ShutdownReceiver {
-            shutdown_rx: shutdown_rx,
+            shutdown_rx,
             _shutdown_confirm_tx: shutdown_confirm_tx,
         },
     )

--- a/src/storage/buckets.rs
+++ b/src/storage/buckets.rs
@@ -90,7 +90,8 @@ impl<T: Bucketable> Buckets<T> {
         let mut all: Vec<&T> = self
             .values()
             .iter()
-            .filter(|item| exclude.is_none() || *exclude.unwrap() != item.get_id()).copied()
+            .filter(|item| exclude.is_none() || *exclude.unwrap() != item.get_id())
+            .copied()
             .collect();
 
         all.sort_unstable_by(|a, b| {
@@ -207,10 +208,7 @@ mod tests {
                 Instant::now()
             };
 
-            TestWrapper {
-                id,
-                first_seen: fs,
-            }
+            TestWrapper { id, first_seen: fs }
         }
     }
 

--- a/src/storage/buckets.rs
+++ b/src/storage/buckets.rs
@@ -20,9 +20,9 @@ pub struct Buckets<T: Bucketable> {
 impl<T: Bucketable> Buckets<T> {
     pub fn new(our_id: Id, k: usize) -> Buckets<T> {
         let mut to_ret = Buckets {
-            our_id: our_id,
+            our_id,
             buckets: Vec::with_capacity(32),
-            k: k,
+            k,
         };
 
         to_ret.buckets.push(Vec::new());
@@ -47,7 +47,7 @@ impl<T: Bucketable> Buckets<T> {
     }
 
     pub fn contains(&self, id: &Id) -> bool {
-        let dest_bucket_idx = self.get_dest_bucket_idx_for_id(&id);
+        let dest_bucket_idx = self.get_dest_bucket_idx_for_id(id);
         if let Some(bucket) = self.buckets.get(dest_bucket_idx) {
             for item in bucket.iter() {
                 if item.get_id() == *id {
@@ -61,7 +61,7 @@ impl<T: Bucketable> Buckets<T> {
     pub fn count(&self) -> usize {
         let mut count = 0;
         for bucket in &self.buckets {
-            count = count + bucket.len();
+            count += bucket.len();
         }
 
         count
@@ -72,7 +72,7 @@ impl<T: Bucketable> Buckets<T> {
     }
 
     pub fn get_mut(&mut self, id: &Id) -> Option<&mut T> {
-        let dest_bucket_idx = self.get_dest_bucket_idx_for_id(&id);
+        let dest_bucket_idx = self.get_dest_bucket_idx_for_id(id);
         if let Some(bucket) = self.buckets.get_mut(dest_bucket_idx) {
             for item in bucket.iter_mut() {
                 if item.get_id() == *id {
@@ -90,8 +90,7 @@ impl<T: Bucketable> Buckets<T> {
         let mut all: Vec<&T> = self
             .values()
             .iter()
-            .filter(|item| exclude.is_none() || *exclude.unwrap() != item.get_id())
-            .map(|item| *item)
+            .filter(|item| exclude.is_none() || *exclude.unwrap() != item.get_id()).copied()
             .collect();
 
         all.sort_unstable_by(|a, b| {
@@ -115,7 +114,7 @@ impl<T: Bucketable> Buckets<T> {
     }
 
     pub fn remove(&mut self, id: &Id) -> Option<T> {
-        let dest_bucket_idx = self.get_dest_bucket_idx_for_id(&id);
+        let dest_bucket_idx = self.get_dest_bucket_idx_for_id(id);
         if let Some(bucket) = self.buckets.get_mut(dest_bucket_idx) {
             for i in 0..bucket.len() {
                 if bucket[i].get_id() == *id {
@@ -176,8 +175,7 @@ impl<T: Bucketable> Buckets<T> {
 
                 // Sort by oldest. Move the newest excess to the chump list
                 if self.buckets[bucket_index].len() > self.k {
-                    self.buckets[bucket_index]
-                        .sort_unstable_by(|a, b| a.get_first_seen().cmp(&b.get_first_seen()));
+                    self.buckets[bucket_index].sort_unstable_by_key(|a| a.get_first_seen());
                     let mut remainder = self.buckets[bucket_index].split_off(self.k);
 
                     if let Some(chump_list) = &mut chump_list {
@@ -185,7 +183,7 @@ impl<T: Bucketable> Buckets<T> {
                     }
                 }
             }
-            bucket_index = bucket_index + 1
+            bucket_index += 1
         }
     }
 }
@@ -210,7 +208,7 @@ mod tests {
             };
 
             TestWrapper {
-                id: id,
+                id,
                 first_seen: fs,
             }
         }
@@ -269,12 +267,12 @@ mod tests {
         let their_id = Id::from_hex("0000000000000000000000000000000000000001").unwrap();
         storage.add(TestWrapper::new(their_id, None), None);
 
-        assert!(storage.count() == 1);
+        assert_eq!(storage.count(), 1);
         assert!(storage.get_mut(&their_id).is_some());
 
         assert!(storage.remove(&their_id).is_some());
         assert!(storage.remove(&their_id).is_none());
-        assert!(storage.count() == 0);
+        assert_eq!(storage.count(), 0);
     }
 
     /// Tests that we only store a max of k items that have nothing in common with our id

--- a/src/storage/node_bucket_storage.rs
+++ b/src/storage/node_bucket_storage.rs
@@ -181,8 +181,7 @@ impl NodeStorage for NodeBucketStorage {
         self.unverified
             .values()
             .iter()
-            .copied()
-            .map(|nw| nw.clone())
+            .copied().cloned()
             .collect()
     }
 
@@ -190,8 +189,7 @@ impl NodeStorage for NodeBucketStorage {
         self.verified
             .values()
             .iter()
-            .copied()
-            .map(|nw| nw.clone())
+            .copied().cloned()
             .collect()
     }
 
@@ -211,7 +209,7 @@ impl NodeStorage for NodeBucketStorage {
                         return last_verified >= time;
                     }
                     trace!(target: "rustydht_lib::NodeBucketStorage", "Verified {:?} hasn't verified recently. Removing.", nw.node);
-                    return false;
+                    false
                 });
                 self.unverified.retain(|nw| {
                     if let Some(last_verified) = nw.last_verified {
@@ -223,7 +221,7 @@ impl NodeStorage for NodeBucketStorage {
                         return true;
                     }
                     trace!(target: "rustydht_lib::NodeBucketStorage", "Unverified {:?} is dead. Removing", nw.node);
-                    return false;
+                    false
                 });
             }
         }

--- a/src/storage/node_bucket_storage.rs
+++ b/src/storage/node_bucket_storage.rs
@@ -178,19 +178,11 @@ impl NodeStorage for NodeBucketStorage {
     }
 
     fn get_all_unverified(&self) -> Vec<NodeWrapper> {
-        self.unverified
-            .values()
-            .iter()
-            .copied().cloned()
-            .collect()
+        self.unverified.values().iter().copied().cloned().collect()
     }
 
     fn get_all_verified(&self) -> Vec<NodeWrapper> {
-        self.verified
-            .values()
-            .iter()
-            .copied().cloned()
-            .collect()
+        self.verified.values().iter().copied().cloned().collect()
     }
 
     fn get_nearest_nodes(&self, id: &Id, exclude: Option<&Id>) -> Vec<Node> {

--- a/src/storage/node_wrapper.rs
+++ b/src/storage/node_wrapper.rs
@@ -27,7 +27,7 @@ impl NodeWrapper {
     pub fn new(node: Node) -> NodeWrapper {
         let now = std::time::Instant::now();
         NodeWrapper {
-            node: node,
+            node,
             first_seen: now,
             last_seen: now,
             last_verified: None,

--- a/src/storage/outbound_request_storage.rs
+++ b/src/storage/outbound_request_storage.rs
@@ -56,10 +56,8 @@ impl OutboundRequestStorage {
                             &request_info.packet.message_type
                         {
                             // Does the response type match the request type?
-                            if crate::packets::response_matches_request(
-                                res_specific,
-                                req_specific,
-                            ) {
+                            if crate::packets::response_matches_request(res_specific, req_specific)
+                            {
                                 return Some(request_info);
                             }
                         }
@@ -94,9 +92,8 @@ impl OutboundRequestStorage {
 
             Some(time) => {
                 let len_before = self.requests.len();
-                self.requests.retain(|_, v| -> bool {
-                    v.created_at >= time
-                });
+                self.requests
+                    .retain(|_, v| -> bool { v.created_at >= time });
                 let len_after = self.requests.len();
                 debug!(target: "rustydht_lib::OutboundRequestStorage", "Pruned {} request records", len_before - len_after);
             }

--- a/src/storage/peer_storage.rs
+++ b/src/storage/peer_storage.rs
@@ -16,7 +16,7 @@ pub struct PeerInfo {
 impl PeerInfo {
     fn new(addr: SocketAddr) -> PeerInfo {
         PeerInfo {
-            addr: addr,
+            addr,
             last_updated: std::time::Instant::now(),
         }
     }
@@ -32,7 +32,7 @@ impl PeerStorage {
     pub fn new(max_torrents: usize, max_peers_per_torrent: usize) -> PeerStorage {
         PeerStorage {
             peers: RefCell::new(LruCache::new(max_torrents)),
-            max_peers_per_torrent: max_peers_per_torrent,
+            max_peers_per_torrent,
         }
     }
 
@@ -73,7 +73,7 @@ impl PeerStorage {
                 .iter()
                 .filter(|pi| pi.0.ip().is_ipv4()) // Only return IPv4 for now, you dog!
                 .filter(|pi| newer_than.is_none() || pi.1.last_updated > newer_than.unwrap())
-                .map(|pi| pi.1.clone())
+                .map(|pi| *pi.1)
                 .collect();
             to_ret.append(&mut tmp);
         }
@@ -83,7 +83,7 @@ impl PeerStorage {
 
     pub fn get_info_hashes(&self) -> Vec<Id> {
         let peers = self.peers.borrow();
-        peers.iter().map(|kv| kv.0.clone()).collect()
+        peers.iter().map(|kv| *kv.0).collect()
     }
 }
 

--- a/src/storage/throttler.rs
+++ b/src/storage/throttler.rs
@@ -53,10 +53,10 @@ impl<const NUM_RECORDS: usize> Throttler<NUM_RECORDS> {
     ) -> Throttler<NUM_RECORDS> {
         Throttler {
             records: [ThrottlerRecord::default(); NUM_RECORDS],
-            rate_limit: rate_limit,
-            period: period,
-            naughty_timeout: naughty_timeout,
-            max_tracking: max_tracking,
+            rate_limit,
+            period,
+            naughty_timeout,
+            max_tracking,
         }
     }
 
@@ -83,9 +83,7 @@ impl<const NUM_RECORDS: usize> Throttler<NUM_RECORDS> {
 
             // Keep track of the saddest/lamest record as we go
             if let Some(lame) = &lamest {
-                if record.packets < lame.packets {
-                    lamest = Some(record);
-                } else if record.packets == lame.packets && record.expiration < lame.expiration {
+                if record.packets < lame.packets || (record.packets == lame.packets && record.expiration < lame.expiration) {
                     lamest = Some(record);
                 }
             } else {
@@ -135,7 +133,7 @@ impl<const NUM_RECORDS: usize> Throttler<NUM_RECORDS> {
     }
 
     pub fn get_num_records(&self) -> usize {
-        return NUM_RECORDS;
+        NUM_RECORDS
     }
 }
 

--- a/src/storage/throttler.rs
+++ b/src/storage/throttler.rs
@@ -83,7 +83,9 @@ impl<const NUM_RECORDS: usize> Throttler<NUM_RECORDS> {
 
             // Keep track of the saddest/lamest record as we go
             if let Some(lame) = &lamest {
-                if record.packets < lame.packets || (record.packets == lame.packets && record.expiration < lame.expiration) {
+                if record.packets < lame.packets
+                    || (record.packets == lame.packets && record.expiration < lame.expiration)
+                {
                     lamest = Some(record);
                 }
             } else {


### PR DESCRIPTION
Hi @raptorswing! I'm going to use your crate for one of my pet projects. But, while exploring the source code I found that there were a lot of clippy warnings. So I fixed them :slightly_smiling_face:. After fixing, I ran unit tests and no one failed. 
Thank you for the project. I really like the code. 

Edit: I only left one warning untouchable:
![2022-01-23_23-41](https://user-images.githubusercontent.com/55661041/150699060-7f5c21f0-cc62-4d7b-a8fd-636e07dff51f.png)
As I don't know how to properly rename the module, or should I  even do it. Leaving it up to you.